### PR TITLE
[mnemonic] Enable recover from mnemonic with unused index

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -75,7 +75,7 @@ func keysSub() []*cobra.Command {
 			return nil
 		},
 	}
-	// add.Flags().BoolVar(&recoverFromMnemonic, "recover", false, "create keys from a mnemonic")
+	add.Flags().BoolVar(&recoverFromMnemonic, "recover", false, "create keys from a mnemonic")
 	ppPrompt := fmt.Sprintf("provide own phrase over default: `%s`", c.DefaultPassphrase)
 	add.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	cmdImport := &cobra.Command{

--- a/pkg/account/creation.go
+++ b/pkg/account/creation.go
@@ -34,7 +34,8 @@ func CreateNewLocalAccount(candidate *Creation) error {
 	if candidate.Mnemonic == "" {
 		candidate.Mnemonic = mnemonic.Generate()
 	}
-	private, _ := keys.FromMnemonicSeedAndPassphrase(candidate.Mnemonic, candidate.Passphrase)
+	// Hardcoded index of 0 here.
+	private, _ := keys.FromMnemonicSeedAndPassphrase(candidate.Mnemonic, 0)
 	_, err := ks.ImportECDSA(private.ToECDSA(), candidate.Passphrase)
 	if err != nil {
 		return err

--- a/pkg/keys/mnemonic.go
+++ b/pkg/keys/mnemonic.go
@@ -8,19 +8,12 @@ import (
 	"github.com/tyler-smith/go-bip39"
 )
 
-// const (
-// 	TestMnemonic   = "quick parade stay hockey build token access sentence choice supply creek twelve"
-// 	TestPassphrase = "edgar"
-// 	TestPrivateKey = "0xc83827745d4e2e74e0b996b2a31ebff7bde72790bf23db839668223c07fb0299"
-// 	TestPublicKey  = "0x038044dbdd8e6f901d26e3e705570b87fa6ca412f435979c60e90539a5b72b5a9f"
-// )
-
-func FromMnemonicSeedAndPassphrase(mnemonic, passphrase string) (*secp256k1.PrivateKey, *secp256k1.PublicKey) {
-	seed := bip39.NewSeed(mnemonic, passphrase)
+// FromMnemonicSeedAndPassphrase mimics the Harmony JS sdk in deriving the
+// private, public key pair from the mnemonic, its index, and empty string password.
+// Note that an index k would be the k-th key generated using the same mnemonic.
+func FromMnemonicSeedAndPassphrase(mnemonic string, index int) (*secp256k1.PrivateKey, *secp256k1.PublicKey) {
+	seed := bip39.NewSeed(mnemonic, "")
 	master, ch := hd.ComputeMastersFromSeed(seed)
-	// TODO Come back to idea of index/issue
-
-	index := 0
 	private, _ := hd.DerivePrivateKeyForPath(
 		master,
 		ch,
@@ -28,32 +21,4 @@ func FromMnemonicSeedAndPassphrase(mnemonic, passphrase string) (*secp256k1.Priv
 	)
 
 	return secp256k1.PrivKeyFromBytes(secp256k1.S256(), private[:])
-
-	// p1 := publicK.SerializeCompressed()
-	// p2 := privateK.Serialize()
-
-	// ePublic := hexutil.Encode(p1)
-	// ePrivate := hexutil.Encode(p2)
-
-	// fmt.Printf("Public: %s \nPrivate: %s\nMnemonic: %s\n",
-	// 	ePublic,
-	// 	ePrivate,
-	// 	TestMnemonic,
-	// )
-
-	// if ePublic != TestPublicKey {
-	// 	fmt.Printf("Error, not public matching %s\n", TestPublicKey)
-	// }
-	// if ePrivate != TestPrivateKey {
-	// 	fmt.Printf("Error, not private matching %s\n", TestPrivateKey)
-	// }
-	// return p1, p2, nil
-	// account, error :=
-	// 	DefaultKS.ImportECDSA(privateK.ToECDSA(), passphrase)
-
-	// fmt.Println(account, error)
 }
-
-// func T() {
-// 	NewAccountFromMnemonicSeedAndPassphrase(TestMnemonic, TestPassphrase)
-// }

--- a/pkg/keys/mnemonic_test.go
+++ b/pkg/keys/mnemonic_test.go
@@ -5,26 +5,22 @@ import (
 )
 
 const (
-	testMnemonic            = "quick parade stay hockey build token access sentence choice supply creek twelve"
-	testPassphrase          = "edgar"
-	testPrivateKey          = "0xc83827745d4e2e74e0b996b2a31ebff7bde72790bf23db839668223c07fb0299"
-	testPublicCompressedKey = "0x038044dbdd8e6f901d26e3e705570b87fa6ca412f435979c60e90539a5b72b5a9f"
-	testPublicKey           = "0x048044dbdd8e6f901d26e3e705570b87fa6ca412f435979c60e90539a5b72b5a9fba25f768b09c869868a5acdb9e64a2f46a3c70c04ccfb1f757f1a9ac2106418f"
+	phrase     = "crouch embrace tree can horn decrease until boil ice edit eagle chimney"
+	index      = 0
+	publicKey  = "0x030b64624e60c6e6758711fdf00f7e873f40a22e647a6918ba73807fab194d09ba"
+	privateKey = "0xda4bc68857640103942ce7dd22a9fcdb96f3cfe0380254e81352a94ac8262ed2"
 )
 
 func TestMnemonic(t *testing.T) {
-	private, public := NewKeysFromMnemonicSeedAndPassphrase(testMnemonic, testPassphrase)
-	sk, pkCompressed, pk := func() (string, string, string) {
+	private, public := FromMnemonicSeedAndPassphrase(phrase, index)
+	sk, pkCompressed := func() (string, string) {
 		dump := EncodeHex(private, public)
-		return dump.PrivateKey, dump.PublicKeyCompressed, dump.PublicKey
+		return dump.PrivateKey, dump.PublicKeyCompressed
 	}()
-	if sk != testPrivateKey {
-		t.Errorf("Private key mismatch %s != %s", sk, testPrivateKey)
+	if sk != privateKey {
+		t.Errorf("Private key mismatch %s != %s", sk, privateKey)
 	}
-	if pkCompressed != testPublicCompressedKey {
-		t.Errorf("Public Compressed key mismatch %s != %s", pkCompressed, testPublicCompressedKey)
-	}
-	if pk != testPublicKey {
-		t.Errorf("Public Compressed key mismatch %s != %s", pk, testPublicKey)
+	if pkCompressed != publicKey {
+		t.Errorf("Public Compressed key mismatch %s != %s", pkCompressed, publicKey)
 	}
 }


### PR DESCRIPTION
To follow exactly what the JS SDK does, the bip39 new seed call has to have an empty string passphrase. Moreover, the addition of the index field is there just in case it is needed in the future. The index is hardcoded to 0 at the moment.