### PR TITLE
Import keys using secp256k1 private keys.

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -96,6 +96,7 @@ func keysSub() []*cobra.Command {
 	cmdImportSK := &cobra.Command{
 		Use:   "import-private-key <secp256k1_PRIVATE_KEY> [ACCOUNT_NAME]",
 		Short: "Import an existing keystore key (only accept secp256k1 private keys)",
+		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			passphrase := c.DefaultPassphrase
 			if userProvidesPassphrase {

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -94,15 +94,15 @@ func keysSub() []*cobra.Command {
 	cmdImportKS.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
 	cmdImportKS.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
 	cmdImportSK := &cobra.Command{
-		Use:   "import-private-key",
-		Short: "Import an existing keystore key (only accept x509 secp256k1)",
+		Use:   "import-private-key <PRIVATE_KEY> <ACCOUNT_NAME>",
+		Short: "Import an existing keystore key (only accept secp256k1 private keys)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			passphrase := c.DefaultPassphrase
 			if userProvidesPassphrase {
 				passphrase = doubleTakePhrase()
 			}
-			name, err := account.ImportFromPrivateKey(args[0], passphrase)
-			if !quietImport {
+			name, err := account.ImportFromPrivateKey(args[0], args[1], passphrase)
+			if !quietImport && err != nil {
 				fmt.Printf("Imported keystore given account alias of `%s`\n", name)
 			}
 			return err

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -78,8 +78,8 @@ func keysSub() []*cobra.Command {
 	add.Flags().BoolVar(&recoverFromMnemonic, "recover", false, "create keys from a mnemonic")
 	ppPrompt := fmt.Sprintf("provide own phrase over default: `%s`", c.DefaultPassphrase)
 	add.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
-	cmdImport := &cobra.Command{
-		Use:   "import <ABSOLUTE_PATH_KEYSTORE>",
+	cmdImportKS := &cobra.Command{
+		Use:   "import-ks <ABSOLUTE_PATH_KEYSTORE>",
 		Args:  cobra.ExactArgs(1),
 		Short: "Import an existing keystore key",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -91,10 +91,23 @@ func keysSub() []*cobra.Command {
 		},
 	}
 	importP := `passphrase of key being imported, default assumes ""`
-	cmdImport.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
-	cmdImport.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
+	cmdImportKS.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
+	cmdImportKS.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
+	const test = "0xc83827745d4e2e74e0b996b2a31ebff7bde72790bf23db839668223c07fb0299"
+	cmdImportSK := &cobra.Command{
+		Use:   "import-private-key",
+		Short: "Import an existing keystore key (only accept x509 secp256k1)",
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-	return []*cobra.Command{add, cmdImport, {
+			name, err := account.ImportKeyStore(test, importPassphrase)
+			// 	if !quietImport {
+			// 		fmt.Printf("Imported keystore given account alias of `%s`\n", name)
+			// 	}
+			return nil
+		},
+	}
+
+	return []*cobra.Command{add, cmdImportKS, cmdImportSK, {
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -93,17 +93,15 @@ func keysSub() []*cobra.Command {
 	importP := `passphrase of key being imported, default assumes ""`
 	cmdImportKS.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
 	cmdImportKS.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
-	const test = "0xc83827745d4e2e74e0b996b2a31ebff7bde72790bf23db839668223c07fb0299"
 	cmdImportSK := &cobra.Command{
 		Use:   "import-private-key",
 		Short: "Import an existing keystore key (only accept x509 secp256k1)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			name, err := account.ImportKeyStore(test, importPassphrase)
-			// 	if !quietImport {
-			// 		fmt.Printf("Imported keystore given account alias of `%s`\n", name)
-			// 	}
-			return nil
+			name, err := account.ImportFromPrivateKey(args[0])
+			if !quietImport {
+				fmt.Printf("Imported keystore given account alias of `%s`\n", name)
+			}
+			return err
 		},
 	}
 

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -94,15 +94,19 @@ func keysSub() []*cobra.Command {
 	cmdImportKS.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
 	cmdImportKS.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
 	cmdImportSK := &cobra.Command{
-		Use:   "import-private-key <PRIVATE_KEY> <ACCOUNT_NAME>",
+		Use:   "import-private-key <secp256k1_PRIVATE_KEY> [ACCOUNT_NAME]",
 		Short: "Import an existing keystore key (only accept secp256k1 private keys)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			passphrase := c.DefaultPassphrase
 			if userProvidesPassphrase {
 				passphrase = doubleTakePhrase()
 			}
-			name, err := account.ImportFromPrivateKey(args[0], args[1], passphrase)
-			if !quietImport && err != nil {
+			userName := ""
+			if len(args) == 2 {
+				userName = args[1]
+			}
+			name, err := account.ImportFromPrivateKey(args[0], userName, passphrase)
+			if !quietImport && err == nil {
 				fmt.Printf("Imported keystore given account alias of `%s`\n", name)
 			}
 			return err

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -97,13 +97,18 @@ func keysSub() []*cobra.Command {
 		Use:   "import-private-key",
 		Short: "Import an existing keystore key (only accept x509 secp256k1)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name, err := account.ImportFromPrivateKey(args[0])
+			passphrase := c.DefaultPassphrase
+			if userProvidesPassphrase {
+				passphrase = doubleTakePhrase()
+			}
+			name, err := account.ImportFromPrivateKey(args[0], passphrase)
 			if !quietImport {
 				fmt.Printf("Imported keystore given account alias of `%s`\n", name)
 			}
 			return err
 		},
 	}
+	cmdImportSK.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 
 	return []*cobra.Command{add, cmdImportKS, cmdImportSK, {
 		Use:   "mnemonic",

--- a/pkg/account/creation.go
+++ b/pkg/account/creation.go
@@ -28,7 +28,7 @@ func IsValidPassphrase(pass string) bool {
 	return true
 }
 
-// By this point assume all the inputs are valid, legitmate
+// CreateNewLocalAccount assumes all the inputs are valid, legitmate
 func CreateNewLocalAccount(candidate *Creation) error {
 	ks := store.FromAccountName(candidate.Name)
 	if candidate.Mnemonic == "" {

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -17,7 +17,7 @@ import (
 var (
 	// ErrNotAbsPath when keypath not absolute path
 	ErrNotAbsPath   = errors.New("keypath is not absolute path")
-	ErrBadKeyLength = errors.New("Invalid private key (possibly wrong length)")
+	ErrBadKeyLength = errors.New("Invalid private key (wrong length)")
 )
 
 // ImportFromPrivateKey allows import of an ECDSA private key
@@ -26,7 +26,10 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 		name = generateName() + "-imported"
 	}
 	privateKeyBytes, err := hex.DecodeString(privateKey)
-	if err != nil || len(privateKeyBytes) != 32 {
+	if err != nil {
+		return "", err
+	}
+	if len(privateKeyBytes) != 32 {
 		return "", ErrBadKeyLength
 	}
 

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -29,11 +29,11 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(privateKeyBytes) != 32 {
+	if len(privateKeyBytes) != common.Secp256k1PrivateKeyBytesLength {
 		return "", ErrBadKeyLength
 	}
 
-	// btcec.PrivKeyFromBytes does not return an error
+	// btcec.PrivKeyFromBytes only returns a secret key and public key
 	sk, _ := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
 	ks := store.FromAccountName(name)
 	_, err = ks.ImportECDSA(sk.ToECDSA(), passphrase)

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -1,12 +1,12 @@
 package account
 
 import (
-	"crypto/x509"
-	"fmt"
+	"encoding/hex"
 	"io/ioutil"
 	"path"
 	"strings"
 
+	"github.com/btcsuite/btcd/btcec"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/harmony-one/go-sdk/pkg/common"
 	"github.com/harmony-one/go-sdk/pkg/mnemonic"
@@ -16,55 +16,25 @@ import (
 
 var (
 	// ErrNotAbsPath when keypath not absolute path
-	ErrNotAbsPath = errors.New("keypath is not absolute path")
+	ErrNotAbsPath   = errors.New("keypath is not absolute path")
+	ErrBadKeyLength = errors.New("Invalid private key (possibly wrong length)")
 )
 
 // ImportFromPrivateKey allows import of an ECDSA private key
-func ImportFromPrivateKey(privateKey []byte) (string, error) {
-	name := generateName() + "-imported"
-	ks := store.FromAccountName(name)
-	sk, b := x509.ParseECPrivateKey(privateKey)
-	// secp256k1
-	/*
-				openssl ecparam -genkey -name secp256k1 -text -noout -outform DER | xxd -p -c 1000 | sed 's/41534e31204f49443a20736563703235366b310a30740201010420/PrivKey: /' | sed 's/a00706052b8104000aa144034200/\'$'\nPubKey: /'
-
-
-				openssl ecparam -genkey -name secp256k1 -text -noout -outform DER | xxd -p -c 1000 | sed 's/41534e31204f49443a20736563703235366b310a30740201010420//' | sed 's/a00706052b8104000aa144034200/\'$'\n/'
-
-				 openssl ecparam -name secp256k1  -param_enc explicit -genkey -out key.pem
-
-
-				https://developers.yubico.com/PIV/Guides/Generating_keys_using_OpenSSL.html
-
-				https://bitcoin.stackexchange.com/questions/59644/how-do-these-openssl-commands-create-a-bitcoin-private-key-from-a-ecdsa-keypair
-
-				http://www.herongyang.com/EC-Cryptography/EC-Key-secp256k1-with-OpenSSL.html
-
-				https://crypto.stackexchange.com/questions/50019/public-key-format-for-ecdsa-as-in-fips-186-4
-
-				https://security.stackexchange.com/questions/84327/converting-ecc-private-key-to-pkcs1-format
-
-				https://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file
-
-				https://golang.org/pkg/crypto/x509/#ParseECPrivateKey
-
-				https://github.com/ethereum/go-ethereum/blob/master/vendor/golang.org/x/crypto/ssh/keys.go
-
-				https://godoc.org/golang.org/x/crypto/ssh
-
-		openssl ecparam -list_curves
-
-	*/
-
-	a, err := ks.ImportECDSA(sk, common.DefaultPassphrase)
-
-	fmt.Println(sk, b, a, err)
-
-	if err != nil {
-		return "", err
+func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
+	if name == "" {
+		name = generateName() + "-imported"
 	}
-	return "", nil
+	privateKeyBytes, err := hex.DecodeString(privateKey)
+	if err != nil || len(privateKeyBytes) != 32 {
+		return "", ErrBadKeyLength
+	}
 
+	// btcec.PrivKeyFromBytes does not return an error
+	sk, _ := btcec.PrivKeyFromBytes(btcec.S256(), privateKeyBytes)
+	ks := store.FromAccountName(name)
+	_, err = ks.ImportECDSA(sk.ToECDSA(), passphrase)
+	return name, err
 }
 
 func generateName() string {

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -1,6 +1,8 @@
 package account
 
 import (
+	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -13,17 +15,59 @@ import (
 )
 
 var (
-	NotAbsPath = errors.New("keypath is not absolute path")
+	// ErrNotAbsPath when keypath not absolute path
+	ErrNotAbsPath = errors.New("keypath is not absolute path")
 )
 
-func ImportKeyStore(keypath, passphrase string) (string, error) {
-	if !path.IsAbs(keypath) {
-		return "", NotAbsPath
+// ImportFromPrivateKey allows import of an ECDSA private key
+func ImportFromPrivateKey(privateKey []byte) (string, error) {
+	name := generateName() + "-imported"
+	ks := store.FromAccountName(name)
+	sk, b := x509.ParseECPrivateKey(privateKey)
+	// secp256k1
+	/*
+				openssl ecparam -genkey -name secp256k1 -text -noout -outform DER | xxd -p -c 1000 | sed 's/41534e31204f49443a20736563703235366b310a30740201010420/PrivKey: /' | sed 's/a00706052b8104000aa144034200/\'$'\nPubKey: /'
+
+
+				openssl ecparam -genkey -name secp256k1 -text -noout -outform DER | xxd -p -c 1000 | sed 's/41534e31204f49443a20736563703235366b310a30740201010420//' | sed 's/a00706052b8104000aa144034200/\'$'\n/'
+
+				 openssl ecparam -name secp256k1  -param_enc explicit -genkey -out key.pem
+
+
+				https://developers.yubico.com/PIV/Guides/Generating_keys_using_OpenSSL.html
+
+				https://bitcoin.stackexchange.com/questions/59644/how-do-these-openssl-commands-create-a-bitcoin-private-key-from-a-ecdsa-keypair
+
+				http://www.herongyang.com/EC-Cryptography/EC-Key-secp256k1-with-OpenSSL.html
+
+				https://crypto.stackexchange.com/questions/50019/public-key-format-for-ecdsa-as-in-fips-186-4
+
+				https://security.stackexchange.com/questions/84327/converting-ecc-private-key-to-pkcs1-format
+
+				https://serverfault.com/questions/9708/what-is-a-pem-file-and-how-does-it-differ-from-other-openssl-generated-key-file
+
+				https://golang.org/pkg/crypto/x509/#ParseECPrivateKey
+
+				https://github.com/ethereum/go-ethereum/blob/master/vendor/golang.org/x/crypto/ssh/keys.go
+
+				https://godoc.org/golang.org/x/crypto/ssh
+
+		openssl ecparam -list_curves
+
+	*/
+
+	a, err := ks.ImportECDSA(sk, common.DefaultPassphrase)
+
+	fmt.Println(sk, b, a, err)
+
+	if err != nil {
+		return "", err
 	}
-	keyJSON, readError := ioutil.ReadFile(keypath)
-	if readError != nil {
-		return "", readError
-	}
+	return "", nil
+
+}
+
+func generateName() string {
 	words := strings.Split(mnemonic.Generate(), " ")
 	existingAccounts := mapset.NewSet()
 	for a := range store.LocalAccounts() {
@@ -46,7 +90,19 @@ func ImportKeyStore(keypath, passphrase string) (string, error) {
 			break
 		}
 	}
-	name := acct + "-imported"
+	return acct
+}
+
+// ImportKeyStore imports a keystore along with a password
+func ImportKeyStore(keypath, passphrase string) (string, error) {
+	if !path.IsAbs(keypath) {
+		return "", ErrNotAbsPath
+	}
+	keyJSON, readError := ioutil.ReadFile(keypath)
+	if readError != nil {
+		return "", readError
+	}
+	name := generateName() + "-imported"
 	ks := store.FromAccountName(name)
 	_, err := ks.Import(keyJSON, passphrase, common.DefaultPassphrase)
 	if err != nil {

--- a/pkg/common/values.go
+++ b/pkg/common/values.go
@@ -11,6 +11,7 @@ const (
 	DefaultConfigAccountAliasesDirName = "account-keys"
 	DefaultPassphrase                  = "harmony-one"
 	JSONRPCVersion                     = "2.0"
+	Secp256k1PrivateKeyBytesLength     = 32
 )
 
 var (

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -24,6 +24,7 @@ func init() {
 	}
 }
 
+// LocalAccounts returns a slice of local account alias names
 func LocalAccounts() []string {
 	uDir, _ := homedir.Dir()
 	files, _ := ioutil.ReadDir(path.Join(

--- a/test.sh
+++ b/test.sh
@@ -4,32 +4,41 @@ source ../harmony/scripts/setup_bls_build_flags.sh
 
 set -eiu
 
+ # ./hmy.sh transfer --amount 100 --chain-id "testnet" --from one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 --to one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 --from-shard 0 --to-shard 1 -n "https://api.s0.b.hmny.io:443"
+
+
 function test_transfer() {
 
     local sd='one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw'
     local rcr='one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6'
     local lcl='http://localhost:9500'
-    local main='https://api.s0.t.hmny.io/'
-    local beta='https://api.s0.b.hmny.io/'
-    local mainDirect='http://18.237.68.133:9500'
+
+    local mainnet='https://api.s0.t.hmny.io/'
+    local testnet='https://api.s0.b.hmny.io/'
+
+    local test_net_direct='http://3.80.213.219:9500'
     local test_debug_x1='one1tp7xdd9ewwnmyvws96au0e7e7mz6f8hjqr3g3p'
     local test_debug_x2='one1spshr72utf6rwxseaz339j09ed8p6f8ke370zj'
 
-    printf 'Before transfer----\nSender:%s Balance\n' ${sd}
-    ./hmy --node=${lcl} balance ${test_debug_x1}
-    printf 'Receiver %s Balance:\n' ${rcr}
-    ./hmy --node=${lcl} balance ${test_debug_x2}
+    local jg5='one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5'
 
-    HMY_RPC_DEBUG=true HMY_TX_DEBUG=true ./hmy --node=${lcl} \
-    	  transfer --from ${test_debug_x2} --to ${test_debug_x1} --chain-id='mainnet' \
-    	  --from-shard 0 --to-shard 0 --amount 1
+    local spc='https://api.s0.b.hmny.io:443'
+
+    printf 'Before transfer----\nSender:%s Balance\n' ${test_net_direct}
+    ./hmy --node=${test_net_direct} balance ${jg5}
+    # printf 'Receiver %s Balance:\n' ${rcr}
+    # ./hmy --node=${testnet} balance ${test_debug_x2}
+
+    ./hmy --node=${test_net_direct} --verbose \
+    	  transfer --from ${jg5} --to ${jg5} \
+    	  --from-shard 0 --to-shard 1 --amount 100 --chain-id="mainnet"
 
     sleep 12
 
-    printf 'After transfer----\nReceiver:%s Balance\n' ${rcr}
-    ./hmy --node=${main} balance ${rcr}
-    printf 'Sender %s Balance:\n' ${sd}
-    ./hmy --node=${main} balance ${sd}
+    # printf 'After transfer----\nReceiver:%s Balance\n' ${rcr}
+    # ./hmy --node=${beta} balance ${rcr}
+    # printf 'Sender %s Balance:\n' ${sd}
+    # ./hmy --node=${beta} balance ${sd}
 
 }
 

--- a/test.sh
+++ b/test.sh
@@ -4,41 +4,32 @@ source ../harmony/scripts/setup_bls_build_flags.sh
 
 set -eiu
 
- # ./hmy.sh transfer --amount 100 --chain-id "testnet" --from one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 --to one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5 --from-shard 0 --to-shard 1 -n "https://api.s0.b.hmny.io:443"
-
-
 function test_transfer() {
 
     local sd='one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw'
     local rcr='one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6'
     local lcl='http://localhost:9500'
-
-    local mainnet='https://api.s0.t.hmny.io/'
-    local testnet='https://api.s0.b.hmny.io/'
-
-    local test_net_direct='http://3.80.213.219:9500'
+    local main='https://api.s0.t.hmny.io/'
+    local beta='https://api.s0.b.hmny.io/'
+    local mainDirect='http://18.237.68.133:9500'
     local test_debug_x1='one1tp7xdd9ewwnmyvws96au0e7e7mz6f8hjqr3g3p'
     local test_debug_x2='one1spshr72utf6rwxseaz339j09ed8p6f8ke370zj'
 
-    local jg5='one1puj38zamhlu89enzcdjw6rlhlqtyp2c675hjg5'
+    printf 'Before transfer----\nSender:%s Balance\n' ${sd}
+    ./hmy --node=${lcl} balance ${test_debug_x1}
+    printf 'Receiver %s Balance:\n' ${rcr}
+    ./hmy --node=${lcl} balance ${test_debug_x2}
 
-    local spc='https://api.s0.b.hmny.io:443'
-
-    printf 'Before transfer----\nSender:%s Balance\n' ${test_net_direct}
-    ./hmy --node=${test_net_direct} balance ${jg5}
-    # printf 'Receiver %s Balance:\n' ${rcr}
-    # ./hmy --node=${testnet} balance ${test_debug_x2}
-
-    ./hmy --node=${test_net_direct} --verbose \
-    	  transfer --from ${jg5} --to ${jg5} \
-    	  --from-shard 0 --to-shard 1 --amount 100 --chain-id="mainnet"
+    HMY_RPC_DEBUG=true HMY_TX_DEBUG=true ./hmy --node=${lcl} \
+    	  transfer --from ${test_debug_x2} --to ${test_debug_x1} --chain-id='mainnet' \
+    	  --from-shard 0 --to-shard 0 --amount 1
 
     sleep 12
 
-    # printf 'After transfer----\nReceiver:%s Balance\n' ${rcr}
-    # ./hmy --node=${beta} balance ${rcr}
-    # printf 'Sender %s Balance:\n' ${sd}
-    # ./hmy --node=${beta} balance ${sd}
+    printf 'After transfer----\nReceiver:%s Balance\n' ${rcr}
+    ./hmy --node=${main} balance ${rcr}
+    printf 'Sender %s Balance:\n' ${sd}
+    ./hmy --node=${main} balance ${sd}
 
 }
 


### PR DESCRIPTION
Given a secp256k1 private key, like the one generated from the following command:

```
openssl ecparam -genkey -name secp256k1 -text -noout -outform DER | xxd -p -c 1000 | sed 's/41534e31204f49443a20736563703235366b310a30740201010420/PrivKey: /' | sed 's/a00706052b8104000aa144034200/\'$'\nPubKey: /'
```

You can import the key with an optional name and passphrase. For example:
```
./hmy keys import-private-key b8798ca0a56ce16517ea37c6b1229cbb67cf0e022c423b044fe8f537830d8be5 foo-bar-baz --passphrase
```