### PR TITLE
Raw txn

### DIFF
--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -124,6 +124,7 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 				fmt.Println(common.ToJSONUnsafe(ctrlr.Receipt(), !noPrettyOutput))
 			case dryRun:
 				fmt.Println(ctrlr.TransactionToJSON(!noPrettyOutput))
+				fmt.Println("RawTxn:", ctrlr.RawTransaction())
 			}
 			return nil
 		},

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -123,6 +123,7 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 			case !dryRun && confirmWait > 0:
 				fmt.Println(common.ToJSONUnsafe(ctrlr.Receipt(), !noPrettyOutput))
 			case dryRun:
+				fmt.Println("Txn:")
 				fmt.Println(ctrlr.TransactionToJSON(!noPrettyOutput))
 				fmt.Println("RawTxn:", ctrlr.RawTransaction())
 			}

--- a/pkg/transaction/controller.go
+++ b/pkg/transaction/controller.go
@@ -194,6 +194,10 @@ func (C *Controller) TransactionToJSON(pretty bool) string {
 	return string(r)
 }
 
+func (C *Controller) RawTransaction() string {
+	return *C.transactionForRPC.signature
+}
+
 func (C *Controller) signAndPrepareTxEncodedForSending() {
 	if C.failure != nil {
 		return


### PR DESCRIPTION
RawTxn is appended to the end of the dry-run output.

For example:
```
./hmy --node=https://api.s0.b.hmny.io/ transfer --from one1shzkj8tty2wu230wsjc7lp9xqkwhch2ea7sjhc --to one1a5r9pyvz5eln8huyf3ernqnj6g7gz8z5x626jf --from-shard 0 --to-shard 1 --amount 1 --passphrase='' --chain-id testnet --dry-run
```

Will output:
```
Txn:
{
  "nonce": "0x6c",
  "gasPrice": "0x0",
  "gas": "0x5208",
  "shardID": 0,
  "toShardID": 1,
  "to": "0xed06509182a67f33df844c72398272d23c811c54",
  "value": "0xde0b6b3a7640000",
  "input": "0x",
  "v": "0x28",
  "r": "0x1c9cd0e53cc1ac8837972488e3e5aa88f84f8b3e820dfd6077e8c9be45209a08",
  "s": "0x46df88bf48ff8a2814f0f1915d9f333c4a6bfe9bb31706fa9ac5d2f8d26aa4c",
  "hash": "0x50318dee8d4ad1863bd7cae4d229cc6d89af1684b250ca90a0608c4b8e9b2157"
}
RawTxn: 0xf8696c80825208800194ed06509182a67f33df844c72398272d23c811c54880de0b6b3a76400008028a01c9cd0e53cc1ac8837972488e3e5aa88f84f8b3e820dfd6077e8c9be45209a08a0046df88bf48ff8a2814f0f1915d9f333c4a6bfe9bb31706fa9ac5d2f8d26aa4c
```

*Use Case:* Need it for SDK testing and possibly benchmarking. 