### PR TITLE
pkg/validation: Validation methods for addresses and shardIDs

### DIFF
--- a/cmd/subcommands/custom-flags.go
+++ b/cmd/subcommands/custom-flags.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/harmony-one/go-sdk/pkg/address"
 	"github.com/harmony-one/go-sdk/pkg/common"
+	"github.com/harmony-one/go-sdk/pkg/validation"
 	"github.com/pkg/errors"
 )
 
@@ -15,7 +16,12 @@ func (oneAddress oneAddress) String() string {
 }
 
 func (oneAddress *oneAddress) Set(s string) error {
-	_, err := address.Bech32ToAddress(s)
+	err := validation.ValidateAddress(s)
+	if err != nil {
+		return err
+	}
+
+	_, err = address.Bech32ToAddress(s)
 	if err != nil {
 		return errors.Wrap(err, "not a valid one address")
 	}

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -19,8 +19,8 @@ var (
 	fromAddress oneAddress
 	toAddress   oneAddress
 	amount      float64
-	fromShardID int
-	toShardID   int
+	fromShardID uint32
+	toShardID   uint32
 	confirmWait uint32
 	chainName   = chainIDWrapper{chainID: &common.Chain.TestNet}
 	dryRun      bool
@@ -28,14 +28,14 @@ var (
 	gasPrice    float64
 )
 
-func handlerForShard(senderShard int, node string) (*rpc.HTTPMessenger, error) {
+func handlerForShard(senderShard uint32, node string) (*rpc.HTTPMessenger, error) {
 	s, err := sharding.Structure(node)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, shard := range s {
-		if shard.ShardID == senderShard {
+		if uint32(shard.ShardID) == senderShard {
 			return rpc.NewHTTPHandler(shard.HTTP), nil
 		}
 	}
@@ -68,7 +68,7 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 			if err != nil {
 				return err
 			}
-			err = validation.ValidShardIDs(fromShardID, toShardID, len(s))
+			err = validation.ValidShardIDs(fromShardID, toShardID, uint32(len(s)))
 			if err != nil {
 				return err
 			}
@@ -92,8 +92,8 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 				toAddress.String(),
 				"",
 				amount, gasPrice,
-				fromShardID,
-				toShardID,
+				int(fromShardID),
+				int(toShardID),
 			); transactionFailure != nil {
 				return transactionFailure
 			}
@@ -116,8 +116,8 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 	cmdTransfer.Flags().BoolVar(&dryRun, "dry-run", false, "do not send signed transaction")
 	cmdTransfer.Flags().Float64Var(&amount, "amount", 0.0, "amount")
 	cmdTransfer.Flags().Float64Var(&gasPrice, "gas-price", 0.0, "gas price to pay")
-	cmdTransfer.Flags().IntVar(&fromShardID, "from-shard", -1, "source shard id")
-	cmdTransfer.Flags().IntVar(&toShardID, "to-shard", -1, "target shard id")
+	cmdTransfer.Flags().Uint32Var(&fromShardID, "from-shard", 0, "source shard id")
+	cmdTransfer.Flags().Uint32Var(&toShardID, "to-shard", 0, "target shard id")
 	cmdTransfer.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	cmdTransfer.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
 	cmdTransfer.Flags().StringVar(&unlockP,

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -37,17 +37,17 @@ func TestIsValidShard(t *testing.T) {
 	s, _ := sharding.Structure("http://localhost:9500")
 
 	tests := []struct {
-		shardID int
+		shardID uint32
 		exp     bool
 	}{
 		{0, true},
 		{1, true},
-		{-1, false},
+		{98, false},
 		{99, false},
 	}
 
 	for _, test := range tests {
-		valid := ValidShardID(test.shardID, len(s))
+		valid := ValidShardID(test.shardID, uint32(len(s)))
 
 		if valid != test.exp {
 			t.Errorf("ValidShardID(%d) returned %v, expected %v", test.shardID, valid, test.exp)

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -1,0 +1,56 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/harmony-one/go-sdk/pkg/sharding"
+)
+
+func TestIsValidAddress(t *testing.T) {
+	tests := []struct {
+		str string
+		exp bool
+	}{
+		{"one1ay37rp2pc3kjarg7a322vu3sa8j9puahg679z3", true},
+		{"0x7c41E0668B551f4f902cFaec05B5Bdca68b124CE", true},
+		{"onefoofoo", false},
+		{"0xbarbar", false},
+		{"dsasdadsasaadsas", false},
+		{"32312123213213212321", false},
+	}
+
+	for _, test := range tests {
+		err := ValidateAddress(test.str)
+		valid := false
+
+		if err == nil {
+			valid = true
+		}
+
+		if valid != test.exp {
+			t.Errorf("ValidateAddress(\"%s\") returned %v, expected %v", test.str, valid, test.exp)
+		}
+	}
+}
+
+func TestIsValidShard(t *testing.T) {
+	s, _ := sharding.Structure("http://localhost:9500")
+
+	tests := []struct {
+		shardID int
+		exp     bool
+	}{
+		{0, true},
+		{1, true},
+		{-1, false},
+		{99, false},
+	}
+
+	for _, test := range tests {
+		valid := ValidShardID(test.shardID, len(s))
+
+		if valid != test.exp {
+			t.Errorf("ValidShardID(%d) returned %v, expected %v", test.shardID, valid, test.exp)
+		}
+	}
+}

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -28,7 +28,7 @@ func TestIsValidAddress(t *testing.T) {
 		}
 
 		if valid != test.exp {
-			t.Errorf("ValidateAddress(\"%s\") returned %v, expected %v", test.str, valid, test.exp)
+			t.Errorf(`ValidateAddress("%s") returned %v, expected %v`, test.str, valid, test.exp)
 		}
 	}
 }

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -1,0 +1,42 @@
+package validation
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	addressValidationRegexp = regexp.MustCompile(`^(one[a-zA-Z0-9]{39})|(0x[a-fA-F0-9]{40})`)
+)
+
+// ValidateAddress validates that an address is a valid bech32 address (one...) or a valid base16 address (0x...)
+func ValidateAddress(address string) error {
+	matches := addressValidationRegexp.FindAllStringSubmatch(address, -1)
+	if len(matches) == 0 {
+		return fmt.Errorf("The address you supplied (%s) is in an invalid format. Please provide a valid address.", address)
+	}
+
+	return nil
+}
+
+// ValidateShardIDs validates senderShard and receiverShard against the shardCount
+func ValidShardIDs(senderShard int, receiverShard int, shardCount int) error {
+	if !ValidShardID(senderShard, shardCount) {
+		return fmt.Errorf("invalid argument \"%d\" for \"--from-shard\" flag: please specify a valid shard ID using --from-shard and try again!", senderShard)
+	}
+
+	if !ValidShardID(receiverShard, shardCount) {
+		return fmt.Errorf("invalid argument \"%d\" for \"--to-shard\" flag: please specify a valid shard ID using --to-shard and try again!", receiverShard)
+	}
+
+	return nil
+}
+
+// ValidateShard validates that a shardID is within the bounds of the shardCount
+func ValidShardID(shardID int, shardCount int) bool {
+	if shardID < 0 || shardID > (shardCount-1) {
+		return false
+	}
+
+	return true
+}

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -20,7 +20,7 @@ func ValidateAddress(address string) error {
 }
 
 // ValidateShardIDs validates senderShard and receiverShard against the shardCount
-func ValidShardIDs(senderShard int, receiverShard int, shardCount int) error {
+func ValidShardIDs(senderShard uint32, receiverShard uint32, shardCount uint32) error {
 	if !ValidShardID(senderShard, shardCount) {
 		return fmt.Errorf(`invalid argument "%d" for "--from-shard" flag: please specify a valid shard ID using --from-shard and try again!`, senderShard)
 	}
@@ -33,8 +33,8 @@ func ValidShardIDs(senderShard int, receiverShard int, shardCount int) error {
 }
 
 // ValidateShard validates that a shardID is within the bounds of the shardCount
-func ValidShardID(shardID int, shardCount int) bool {
-	if shardID < 0 || shardID > (shardCount-1) {
+func ValidShardID(shardID uint32, shardCount uint32) bool {
+	if shardID > (shardCount - 1) {
 		return false
 	}
 

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -22,11 +22,11 @@ func ValidateAddress(address string) error {
 // ValidateShardIDs validates senderShard and receiverShard against the shardCount
 func ValidShardIDs(senderShard int, receiverShard int, shardCount int) error {
 	if !ValidShardID(senderShard, shardCount) {
-		return fmt.Errorf("invalid argument \"%d\" for \"--from-shard\" flag: please specify a valid shard ID using --from-shard and try again!", senderShard)
+		return fmt.Errorf(`invalid argument "%d" for "--from-shard" flag: please specify a valid shard ID using --from-shard and try again!`, senderShard)
 	}
 
 	if !ValidShardID(receiverShard, shardCount) {
-		return fmt.Errorf("invalid argument \"%d\" for \"--to-shard\" flag: please specify a valid shard ID using --to-shard and try again!", receiverShard)
+		return fmt.Errorf(`invalid argument "%d" for "--to-shard" flag: please specify a valid shard ID using --to-shard and try again!`, receiverShard)
 	}
 
 	return nil


### PR DESCRIPTION
This is a continuation of https://github.com/harmony-one/go-sdk/pull/29.

I refactored the shardID validation methods into pkg/validation/validator.go and I also added the address validation functionality from the previous pull request I made to harmony-one/harmony (https://github.com/harmony-one/harmony/pull/1702).

The test from that PR has also been ported over and is also included in this PR.

### Address validation

#### Before

```
$ hmy transfer --from FOOBAR --to one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --from-shard 0 --to-shard 0 --amount 1
Error: invalid argument "FOOBAR" for "--from" flag: not a valid one address: cannot decode "FOOBAR" as bech32 address: decoding bech32 failed: invalid bech32 string length 6
```

```
$ hmy transfer --from one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --to FOOBAR --from-shard 0 --to-shard 0 --amount 1
Error: invalid argument "FOOBAR" for "--to" flag: not a valid one address: cannot decode "FOOBAR" as bech32 address: decoding bech32 failed: invalid bech32 string length 6
```

#### After

```
$ hmy transfer --from FOOBAR --to one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --from-shard 0 --to-shard 0 --amount 1
Error: invalid argument "FOOBAR" for "--from" flag: The address you supplied (FOOBAR) is in an invalid format. Please provide a valid address.
```

```
$ hmy transfer --from one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --to FOOBAR --from-shard 0 --to-shard 0 --amount 1
Error: invalid argument "FOOBAR" for "--to" flag: The address you supplied (FOOBAR) is in an invalid format. Please provide a valid address.
```

### Shard ID validation
Still the same as previous PR, e.g:

```
$ hmy transfer --from one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --to one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --from-shard 99 --to-shard 99 --amount 1
Error: invalid argument "99" for "--from-shard" flag: please specify a valid shard ID using --from-shard and try again!
```

```
$ hmy transfer --from one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --to one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 --from-shard 0 --to-shard 99 --amount 1
Error: invalid argument "99" for "--to-shard" flag: please specify a valid shard ID using --to-shard and try again!
```

### Test
Run the included test using `go test pkg/validation/*.go`
