### PR TITLE
Added stake support in CLI and ledger HW signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 hmy
 hmy-docs
 dist
+.idea/

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -1,0 +1,204 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/harmony-one/go-sdk/pkg/common"
+	"github.com/harmony-one/go-sdk/pkg/ledger"
+	"github.com/harmony-one/go-sdk/pkg/rpc"
+	"github.com/harmony-one/go-sdk/pkg/store"
+	"strings"
+
+	"github.com/harmony-one/harmony/accounts"
+	"github.com/harmony-one/harmony/accounts/keystore"
+	"github.com/harmony-one/harmony/common/denominations"
+	staking "github.com/harmony-one/harmony/staking/types"
+	"github.com/spf13/cobra"
+	"math/big"
+)
+
+var (
+	delegatorAddress    oneAddress
+	validatorAddress    oneAddress
+	validatorSrcAddress oneAddress
+	validatorDstAddress oneAddress
+	senderAddress       oneAddress
+	stakingAmount       float64
+)
+
+func getNextNonce(messenger rpc.T) uint64 {
+	transactionCountRPCReply, err :=
+		messenger.SendRPC(rpc.Method.GetTransactionCount, []interface{}{accounts.ParseAddrH(delegatorAddress.String()), "latest"})
+
+	if err != nil {
+		return 0
+	}
+
+	transactionCount, _ := transactionCountRPCReply["result"].(string)
+	nonce, _ := big.NewInt(0).SetString(transactionCount[2:], 16)
+	fmt.Println("Nonce = ", nonce.String())
+	return nonce.Uint64()
+}
+
+func createDelegateStakingTransaction(nonce uint64) (*staking.StakingTransaction, error) {
+	amountBigInt := big.NewInt(int64(stakingAmount * denominations.Nano))
+	amt := amountBigInt.Mul(amountBigInt, big.NewInt(denominations.Nano))
+	gasPrice := big.NewInt(int64(gasPrice))
+	gasPrice = gasPrice.Mul(gasPrice, big.NewInt(denominations.Nano))
+
+	//TODO: modify the gas limit calculation algorithm
+	gasLimit, err := core.IntrinsicGas(nil, false, true)
+	if err != nil {
+		return nil, err
+	}
+
+	stakePayloadMaker := func() (staking.Directive, interface{}) {
+		return staking.DirectiveDelegate, staking.Delegate{
+			accounts.ParseAddrH(delegatorAddress.String()),
+			accounts.ParseAddrH(validatorAddress.String()),
+			amt,
+		}
+	}
+
+	stakingTx, err := staking.NewStakingTransaction(nonce, gasLimit, gasPrice, stakePayloadMaker)
+	return stakingTx, err
+}
+
+func stakingSubCommands() []*cobra.Command {
+	subCmdDelegate := &cobra.Command{
+		Use:   "delegate",
+		Short: "delegate staking",
+		Long: `
+Delegating to a validator
+`,
+		Run: func(cmd *cobra.Command, args []string)  {
+			var ks      *keystore.KeyStore
+			var acct    *accounts.Account
+			var signed  *staking.StakingTransaction
+
+			networkHandler, err := handlerForShard(0, node)
+
+			from := delegatorAddress.String()
+			stakingTx, err := createDelegateStakingTransaction(getNextNonce(networkHandler))
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			if useLedgerWallet {
+				var signerAddr string
+				signed, signerAddr, err = ledger.SignStakingTx(stakingTx,  chainName.chainID.Value)
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+
+				if strings.Compare(signerAddr, delegatorAddress.String()) != 0 {
+					fmt.Println("signature verification failed : delegator address doesn't match with ledger hardware addresss")
+					return
+				}
+			} else {
+				ks, acct, err = store.UnlockedKeystore(from, unlockP)
+				if err != nil {
+					fmt.Println(err)
+					return
+				}
+				signed, err = ks.SignStakingTx(*acct, stakingTx, chainName.chainID.Value)
+			}
+
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			enc, err := rlp.EncodeToBytes(signed)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+
+			hexSignature := hexutil.Encode(enc)
+			reply, err := networkHandler.SendRPC(rpc.Method.SendRawStakingTransaction, []interface{}{hexSignature})
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			r, _ := reply["result"].(string)
+			fmt.Println(fmt.Sprintf(`{"transaction-receipt":"%s"}`, r))
+		},
+	}
+
+	subCmdDelegate.Flags().Var(&delegatorAddress, "delegator", "delegator's address")
+	subCmdDelegate.Flags().Var(&validatorAddress, "validator", "validator's address")
+	subCmdDelegate.Flags().Float64Var(&stakingAmount, "staking-amount", 0.0, "staking amount")
+	subCmdDelegate.Flags().Float64Var(&gasPrice, "gas-price", 0.0, "gas price to pay")
+	subCmdDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
+	subCmdDelegate.Flags().StringVar(&unlockP,
+		"passphrase", common.DefaultPassphrase,
+		"passphrase to unlock delegator's keystore",
+	)
+
+	subCmdUnDelegate := &cobra.Command{
+		Use:   "undelegate",
+		Short: "un-delegate staking",
+		Long: `
+Remove delegating to a validator
+`,
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string)  {
+		},
+	}
+
+	subCmdUnDelegate.Flags().Var(&delegatorAddress, "delegator", "delegator's address")
+	subCmdUnDelegate.Flags().Var(&validatorAddress, "validator", "source validator's address")
+	subCmdUnDelegate.Flags().Float64Var(&stakingAmount, "staking-amount", 0.0, "staking amount")
+	subCmdUnDelegate.Flags().Float64Var(&gasPrice, "gas-price", 0.0, "gas price to pay")
+	subCmdUnDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
+	subCmdUnDelegate.Flags().StringVar(&unlockP,
+		"passphrase", common.DefaultPassphrase,
+		"passphrase to unlock delegator's keystore",
+	)
+	subCmdReDelegate := &cobra.Command{
+		Use:   "redelegate",
+		Short: "re-delegate staking",
+		Long: `
+Re-delegating to a validator
+`,
+		Run: func(cmd *cobra.Command, args []string)  {
+		},
+	}
+
+	subCmdReDelegate.Flags().Var(&delegatorAddress, "delegator", "delegator's address")
+	subCmdReDelegate.Flags().Float64Var(&stakingAmount, "staking-amount", 0.0, "staking amount")
+	subCmdReDelegate.Flags().Var(&validatorSrcAddress, "src-validator", "source validator's address")
+	subCmdReDelegate.Flags().Var(&validatorDstAddress, "dest-validator", "destination validator's address")
+	subCmdReDelegate.Flags().Float64Var(&gasPrice, "gas-price", 0.0, "gas price to pay")
+	subCmdReDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
+	subCmdReDelegate.Flags().StringVar(&unlockP,
+		"passphrase", common.DefaultPassphrase,
+		"passphrase to unlock delegator's keystore",
+	)
+
+	return []*cobra.Command{subCmdDelegate,
+		subCmdUnDelegate,
+		subCmdReDelegate,
+	}
+}
+
+func init() {
+	cmdStaking := &cobra.Command{
+		Use:   "staking",
+		Short: "Stake, delegate or undelegate",
+		Long: `
+Create a staking transaction, sign it, and send off to the Harmony blockchain
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmdStaking.AddCommand(stakingSubCommands()...)
+	RootCmd.AddCommand(cmdStaking)
+}

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	BLS_PUB_KEY_SIZE       = 48
+	blsPubKeySize       = 48
 )
 
 var (
@@ -125,34 +125,29 @@ func stakingSubCommands() []*cobra.Command {
 		Long: `
 Create a new validator"
 `,
-		Run: func(cmd *cobra.Command, args []string)  {
+		RunE: func(cmd *cobra.Command, args []string)  error {
 			networkHandler, err := handlerForShard(0, node)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			commisionRate, err := numeric.NewDecFromStr(commisionRateStr)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			commisionMaxRate, err := numeric.NewDecFromStr(commisionMaxRateStr)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			commisionMaxChangeRate, err := numeric.NewDecFromStr(commisionMaxChangeRateStr)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
-			if len(stakingBlsPubKey) != BLS_PUB_KEY_SIZE {
-				fmt.Println("staking BLS pubkey key size should be ", BLS_PUB_KEY_SIZE, " bytes")
-				return
+			if len(stakingBlsPubKey) != blsPubKeySize {
+				return errors.New("staking BLS pubkey key size should be 48 bytes")
 			}
 
 			delegateStakePayloadMaker := func() (staking.Directive, interface{}) {
@@ -187,15 +182,14 @@ Create a new validator"
 
 			stakingTx, err := createStakingTransaction(getNextNonce(networkHandler), delegateStakePayloadMaker)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			err = handleStakingTransaction(stakingTx, networkHandler, stakingAddress)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 
@@ -228,19 +222,17 @@ Create a new validator"
 		Use:   "editvalidator",
 		Short: "edit a validator",
 		Long: `
-Edit an existing validatoa validator"
+Edit an existing validator"
 `,
-		Run: func(cmd *cobra.Command, args []string)  {
+		RunE: func(cmd *cobra.Command, args []string)  error {
 			networkHandler, err := handlerForShard(0, node)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			commisionRate, err := numeric.NewDecFromStr(commisionRateStr)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			delegateStakePayloadMaker := func() (staking.Directive, interface{}) {
@@ -264,15 +256,14 @@ Edit an existing validatoa validator"
 
 			stakingTx, err := createStakingTransaction(getNextNonce(networkHandler), delegateStakePayloadMaker)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			err = handleStakingTransaction(stakingTx, networkHandler, stakingAddress)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 
@@ -303,11 +294,10 @@ Edit an existing validatoa validator"
 		Long: `
 Delegating to a validator
 `,
-		Run: func(cmd *cobra.Command, args []string)  {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			networkHandler, err := handlerForShard(0, node)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			delegateStakePayloadMaker := func() (staking.Directive, interface{}) {
@@ -323,15 +313,14 @@ Delegating to a validator
 
 			stakingTx, err := createStakingTransaction(getNextNonce(networkHandler), delegateStakePayloadMaker)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 
@@ -355,11 +344,10 @@ Delegating to a validator
 		Long: `
 Remove delegating to a validator
 `,
-		Run: func(cmd *cobra.Command, args []string)  {
+		RunE: func(cmd *cobra.Command, args []string) error  {
 			networkHandler, err := handlerForShard(0, node)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			delegateStakePayloadMaker := func() (staking.Directive, interface{}) {
@@ -375,15 +363,14 @@ Remove delegating to a validator
 
 			stakingTx, err := createStakingTransaction(getNextNonce(networkHandler), delegateStakePayloadMaker)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 
@@ -407,11 +394,10 @@ Remove delegating to a validator
 		Long: `
 Re-delegating to a validator
 `,
-		Run: func(cmd *cobra.Command, args []string)  {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			networkHandler, err := handlerForShard(0, node)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			delegateStakePayloadMaker := func() (staking.Directive, interface{}) {
@@ -428,15 +414,14 @@ Re-delegating to a validator
 
 			stakingTx, err := createStakingTransaction(getNextNonce(networkHandler), delegateStakePayloadMaker)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
 
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
-				fmt.Println(err)
-				return
+				return err
 			}
+			return nil
 		},
 	}
 
@@ -471,8 +456,9 @@ func init() {
 		Long: `
 Create a staking transaction, sign it, and send off to the Harmony blockchain
 `,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.Help()
+			return nil
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/elastic/gosigar v0.10.5 // indirect
 	github.com/ethereum/go-ethereum v1.8.27
 	github.com/fatih/color v1.7.0
-	github.com/harmony-one/harmony v0.0.0-20190910224338-d385233a2a70
+	github.com/harmony-one/harmony v0.0.0-20191016204525-3e8309423cc8
+	github.com/harmony-one/vdf v1.0.0 // indirect
 	github.com/karalabe/hid v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,11 @@ github.com/harmony-one/bls v0.0.5 h1:7vWOCPyKbmoqlM2ruBwY93PVTrBzkXpML41NJFJ6jkw
 github.com/harmony-one/bls v0.0.5/go.mod h1:ML9osB/z3hR9WAYZVj7qH+IP6oaPRPmshDbxrQyia7g=
 github.com/harmony-one/harmony v0.0.0-20190910224338-d385233a2a70 h1:06YA5S7GfSq97JxQdRE8DcIE+NUUN2LpoFMXLLzKRqU=
 github.com/harmony-one/harmony v0.0.0-20190910224338-d385233a2a70/go.mod h1:gAjEBUb369WARYdeC8FOM68wA/JTTjVtC6yJKgSBrYE=
+github.com/harmony-one/harmony v0.0.0-20191016204525-3e8309423cc8 h1:CxgIl19HjosG4Sb7uh1rxH+HTA9NxmzcghvfUNuR1EE=
+github.com/harmony-one/harmony v0.0.0-20191016204525-3e8309423cc8/go.mod h1:F9/4Jj858j4th+pDeTAR434vS07nVz87TOFLYrpxJpc=
 github.com/harmony-one/taggedrlp v0.1.2 h1:lAHV4UhBE45W+i7duAAWOgaQNUjDIG6rUydz/5Oqric=
 github.com/harmony-one/taggedrlp v0.1.2/go.mod h1:AK7o802368ESS3v4WZI5DzaHv9q0CsdgR9jPVJ6zleg=
+github.com/harmony-one/vdf v0.0.0-20190924175951-620379da8849/go.mod h1:EgNU7X5HLNBBho+OqCm1A1NrpD6xb1SHfi9pMCYaKKw=
 github.com/harmony-one/vdf v1.0.0/go.mod h1:4Djwf4D14tGBmu1xfx8+HMz/sYSAffVOJNv2FRaAz5M=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
@@ -371,7 +374,10 @@ github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165/go.mod h1:bCqn
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.6.0 h1:G9tHG9lebljV9mfp9SNPDL36nCDxmo3zTlAf1YgvzmI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.14.3 h1:4EGfSkR2hJDB0s3oFfrlPqjU1e4WLncergLil3nEKW0=
 github.com/rs/zerolog v1.14.3/go.mod h1:3WXPzbXEEliJ+a6UFE4vhIxV8qR1EML6ngzP9ug4eYg=
@@ -487,6 +493,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -529,6 +536,7 @@ golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190827205025-b29f5f60c37a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/pkg/ledger/hw_wallet.go
+++ b/pkg/ledger/hw_wallet.go
@@ -1,19 +1,20 @@
 package ledger
 
 import (
+	"bytes"
 	"fmt"
-	"sync"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
 	"log"
 	"math/big"
 	"os"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
-
 	"github.com/harmony-one/go-sdk/pkg/address"
 	"github.com/harmony-one/harmony/core/types"
+	staking "github.com/harmony-one/harmony/staking/types"
 )
 
 var (
@@ -170,4 +171,54 @@ func eip155SignerSignatureValues(chainID *big.Int, sig []byte) (R, S, V *big.Int
 		V.Add(V, chainIDMul)
 	}
 	return R, S, V, nil
+}
+
+// SignTx signs the given transaction with ledger.
+func SignStakingTx(tx *staking.StakingTransaction, chainID *big.Int) (*staking.StakingTransaction, string, error) {
+	//get the RLP encoding of raw staking with R,S,V = 0
+	w := &bytes.Buffer{}
+	err := tx.EncodeRLP(w)
+	if err != nil  {
+		return nil, "", err
+	}
+	rlpEncodedTx := w.Bytes()
+
+	//get the RLP encoding of chain data
+	chainData, _ := rlp.EncodeToBytes([]interface{}{
+		chainID, uint(0), uint(0),
+	})
+
+	//replace R,S,V with RLP encoded (chainID, 0, 0)
+	rlpEncodedTx = append(rlpEncodedTx[0:len(rlpEncodedTx)-3], chainData[1:]...)
+
+	//send the RLP encoded staking tx to ledger
+	n := getLedger()
+	sig, err := n.SignStaking(rlpEncodedTx)
+	if err != nil {
+		log.Println("Couldn't sign staking transaction, error:", err)
+		return nil, "", err
+	}
+
+	var hashBytes [32]byte
+	hw := sha3.NewLegacyKeccak256()
+	hw.Write(rlpEncodedTx[:])
+	hw.Sum(hashBytes[:0])
+
+	pubkey, err := crypto.Ecrecover(hashBytes[:], sig[:])
+	if err != nil {
+		log.Println("Ecrecover failed :", err)
+		return nil, "", err
+	}
+
+	if len(pubkey) == 0 || pubkey[0] != 4 {
+		log.Println("invalid public key")
+		return nil, "", err
+	}
+
+	pubBytes := crypto.Keccak256(pubkey[1:65])[12:]
+	signerAddr, _ := address.ConvertAndEncode("one", pubBytes)
+
+	// WithSignature returns a new transaction with the given signature.
+	rawTx, err := tx.WithSignature(staking.NewEIP155Signer(chainID), sig[:])
+	return rawTx, signerAddr, err
 }

--- a/pkg/ledger/nano_S_driver.go
+++ b/pkg/ledger/nano_S_driver.go
@@ -168,7 +168,7 @@ func (n *NanoS) Exchange(cmd byte, p1, p2 byte, data []byte) (resp []byte, err e
 const (
 	cmdGetVersion   = 0x01
 	cmdGetPublicKey = 0x02
-	cmdSignHash     = 0x04
+	cmdSignStaking  = 0x04
 	cmdSignTx       = 0x08
 
 	p1More  = 0x80
@@ -201,26 +201,28 @@ func (n *NanoS) GetAddress() (oneAddr string, err error) {
 	return string(pubkey[:]), nil
 }
 
-func (n *NanoS) SignHash(hash [32]byte) (sig [65]byte, err error) {
-	resp, err := n.Exchange(cmdSignHash, 0, 0, hash[:])
-	if err != nil {
-		return [65]byte{}, err
-	}
-
-	if copy(sig[:], resp) != len(sig) {
-		return [65]byte{}, errors.New("signature has wrong length")
-	}
-
-
-	//crypto.Sign(hash[:],
-	return sig, nil
-}
-
 func (n *NanoS) SignTxn(txn []byte) (sig [65]byte, err error) {
 	var resp []byte
 
 	var p1 byte = p1More
 	resp, err = n.Exchange(cmdSignTx, p1, p2SignHash, txn)
+	if err != nil {
+		return [65]byte{}, err
+	}
+
+	copy(sig[:], resp)
+
+	if copy(sig[:], resp) != len(sig) {
+		return [65]byte{}, errors.New("signature has wrong length")
+	}
+	return
+}
+
+func (n *NanoS) SignStaking(stake []byte) (sig [65]byte, err error) {
+	var resp []byte
+
+	var p1 byte = p1More
+	resp, err = n.Exchange(cmdSignStaking, p1, p2SignHash, stake)
 	if err != nil {
 		return [65]byte{}, err
 	}

--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -46,6 +46,7 @@ type rpcEnumList struct {
 	ProtocolVersion                     method
 	GetNodeMetadata                     method
 	GetLatestBlockHeader                method
+	SendRawStakingTransaction           method
 }
 
 // Method is a list of known RPC methods
@@ -84,6 +85,7 @@ var Method = rpcEnumList{
 	UnSubscribe:                         "hmy_unsubscribe",
 	NetVersion:                          "net_version",
 	ProtocolVersion:                     "hmy_protocolVersion",
+	SendRawStakingTransaction:           "hmy_sendRawStakingTransaction",
 }
 
 // TODO Use Reflection here to avoid typing out the cases


### PR DESCRIPTION
Support all 5 commands in CLI for staking: 

```
./hmy staking delegate --delegator one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6  --validator one15l3pj0v9a8gfkdatd5hpj029kvc4mlr6r5djmg --gas-price 2  --staking-amount 12345 --passphrase "harmony-one" --ledger
{"transaction-receipt":"0xde39174ce840a2c4addc40820dc1350e380ce64bc87362820493ac19a63325d3"} 
```
```
 ./hmy staking newvalidator --amount 123 --details details --gas-price 20 --identity identity --max-change-rate 12.22 --max-rate 1.2 --min-self-delegation "32.10" --name name  --pubkey 111111111111111111111111111111111111111111111111 --rate "12.2" --security-contact smith --staking-addr one1sl6hku7wxgxnhajrc0a96p6zpea6qr0p0sqajk --website harmony.one --passphrase "harmony-one"
{"transaction-receipt":"0x3e07eb4a2f2e9401623d23c86f9c819828e630b39cbc6dbeb38c3cf6d6c91b8d"}
```
```
./hmy staking editvalidator  --details details --gas-price 20 --identity identity  --min-self-delegation "32.10" --name name   --rate "12.2" --security-contact smith --staking-addr one1sl6hku7wxgxnhajrc0a96p6zpea6qr0p0sqajk --website harmony.one --passphrase "harmony-one"{"transaction-receipt":"0xfccbbcee6c37f4d3bf644012936b7b8f8d4da2487b1f08afbe363bda230b557b"}
```