### PR TITLE
Add export for account's secp256k1 private key and keystore file

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -122,7 +122,35 @@ func keysSub() []*cobra.Command {
 	}
 	cmdImportSK.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 
-	return []*cobra.Command{add, cmdImportKS, cmdImportSK, {
+	cmdExportSK := &cobra.Command{
+		Use:   "export-private-key <ACCOUNT_ADDRESS>",
+		Short: "Export the secp256k1 private key",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := account.ExportPrivateKey(args[0], unlockP)
+			return err
+		},
+	}
+	cmdExportSK.Flags().StringVar(&unlockP,
+		"passphrase", c.DefaultPassphrase,
+		"passphrase to unlock sender's keystore",
+	)
+
+	cmdExportKS := &cobra.Command{
+		Use:   "export-ks <ACCOUNT_ADDRESS>",
+		Short: "Export the keystore file contents",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := account.ExportKeystore(args[0], unlockP)
+			return err
+		},
+	}
+	cmdExportKS.Flags().StringVar(&unlockP,
+		"passphrase", c.DefaultPassphrase,
+		"passphrase to unlock sender's keystore",
+	)
+
+	return []*cobra.Command{add, cmdImportKS, cmdImportSK, cmdExportKS, cmdExportSK, {
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/account/export.go
+++ b/pkg/account/export.go
@@ -1,0 +1,33 @@
+package account
+
+import (
+	"fmt"
+	"github.com/harmony-one/go-sdk/pkg/store"
+	"github.com/harmony-one/harmony/accounts"
+)
+
+func ExportPrivateKey(address, passphrase string) error {
+	ks := store.FromAddress(address)
+	allAccounts := ks.Accounts()
+	for _, account := range allAccounts {
+		_, key, err := ks.GetDecryptedKey(accounts.Account{Address: account.Address}, passphrase)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%x\n", key.PrivateKey.D)
+	}
+	return nil
+}
+
+func ExportKeystore(address, passphrase string) error {
+	ks := store.FromAddress(address)
+	allAccounts := ks.Accounts()
+	for _, account := range allAccounts {
+		keyFile, err := ks.Export(accounts.Account{Address: account.Address}, passphrase, passphrase)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", keyFile)
+	}
+	return nil
+}

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -25,6 +25,9 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 	if name == "" {
 		name = generateName() + "-imported"
 	}
+	if privateKey[:2] == "0x" {
+		privateKey = privateKey[2:]
+	}
 	privateKeyBytes, err := hex.DecodeString(privateKey)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Given an account's address **in the CLI's Keystore**, we can export its secp256k1 private key with the following command:
```
./hmy keys export-private-key one1a7tlnl08s978687zjsdns3m5dckdm0hnxxlwkt
```
We can export the Keystore contents with the following command:
```
./hmy keys export-ks one1a7tlnl08s978687zjsdns3m5dckdm0hnxxlwkt
```