### PR TITLE
Updated staking support for CLI

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -93,7 +93,7 @@ func handleStakingTransaction(
 			return err
 		}
 
-		if strings.Compare(signerAddr, delegatorAddress.String()) != 0 {
+		if strings.Compare(signerAddr, from) != 0 {
 			return errors.New("error : delegator address doesn't match with ledger hardware addresss")
 		}
 	} else {
@@ -171,9 +171,10 @@ Create a new validator"
 				minSelfDel := minSelfDelegationBigInt.Mul(minSelfDelegationBigInt, big.NewInt(denominations.Nano))
 
 				maxTotalDelegationBigInt := big.NewInt(int64(maxTotalDelegation * denominations.Nano))
-				maxTotalDel := minSelfDelegationBigInt.Mul(maxTotalDelegationBigInt, big.NewInt(denominations.Nano))
+				maxTotalDel := maxTotalDelegationBigInt.Mul(maxTotalDelegationBigInt, big.NewInt(denominations.Nano))
 
 				return staking.DirectiveCreateValidator, staking.CreateValidator{
+					address.Parse(validatorAddress.String()),
 					&staking.Description{
 						validatorName,
 						validatorIdentity,
@@ -187,7 +188,6 @@ Create a new validator"
 						commisionMaxChangeRate},
 					minSelfDel,
 					maxTotalDel,
-					address.Parse(validatorAddress.String()),
 					blsPubKeys,
 					amt,
 				}
@@ -272,7 +272,7 @@ Edit an existing validator"
 				minSelfDel := minSelfDelegationBigInt.Mul(minSelfDelegationBigInt, big.NewInt(denominations.Nano))
 
 				maxTotalDelegationBigInt := big.NewInt(int64(maxTotalDelegation * denominations.Nano))
-				maxTotalDel := minSelfDelegationBigInt.Mul(maxTotalDelegationBigInt, big.NewInt(denominations.Nano))
+				maxTotalDel := maxTotalDelegationBigInt.Mul(maxTotalDelegationBigInt, big.NewInt(denominations.Nano))
 
 				return staking.DirectiveEditValidator, staking.EditValidator{
 					address.Parse(validatorAddress.String()),
@@ -312,8 +312,6 @@ Edit an existing validator"
 	subCmdEditValidator.Flags().StringVar(&validatorSecurityContact, "security-contact", "", "validator's security contact")
 	subCmdEditValidator.Flags().StringVar(&validatorDetails, "details", "", "validator's details")
 	subCmdEditValidator.Flags().StringVar(&commisionRateStr, "rate", "", "commission rate")
-	subCmdEditValidator.Flags().StringVar(&commisionMaxRateStr, "max-rate", "", "commision max rate")
-	subCmdEditValidator.Flags().StringVar(&commisionMaxChangeRateStr, "max-change-rate", "", "commission max change amount")
 	subCmdEditValidator.Flags().Float64Var(&minSelfDelegation, "min-self-delegation", 0.0, "minimal self delegation")
 	subCmdEditValidator.Flags().Float64Var(&maxTotalDelegation, "max-total-delegation", 0.0, "maximal total delegation")
 	subCmdEditValidator.Flags().Var(&validatorAddress, "validator-addr", "validator's staking address")
@@ -327,8 +325,8 @@ Edit an existing validator"
 		"passphrase to unlock delegator's keystore",
 	)
 
-	for _, flagName := range [...]string{"name", "identity", "website", "security-contact", "details", "rate", "max-rate",
-		"max-change-rate", "min-self-delegation", "max-total-delegation", "validator-addr", "remove-bls-key", "add-bls-key"} {
+	for _, flagName := range [...]string{"name", "identity", "website", "security-contact", "details", "rate",
+		"min-self-delegation", "max-total-delegation", "validator-addr", "remove-bls-key", "add-bls-key"} {
 		subCmdEditValidator.MarkFlagRequired(flagName)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ethereum/go-ethereum v1.8.27
 	github.com/fatih/color v1.7.0
 	github.com/harmony-one/bls v0.0.5
-	github.com/harmony-one/harmony v0.0.0-20191029195210-b3eeed6b4152
+	github.com/harmony-one/harmony v0.0.0-20191106012056-10f5d6274891
 	github.com/harmony-one/vdf v1.0.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/karalabe/hid v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/harmony-one/harmony v0.0.0-20191016204525-3e8309423cc8 h1:CxgIl19Hjos
 github.com/harmony-one/harmony v0.0.0-20191016204525-3e8309423cc8/go.mod h1:F9/4Jj858j4th+pDeTAR434vS07nVz87TOFLYrpxJpc=
 github.com/harmony-one/harmony v0.0.0-20191029195210-b3eeed6b4152 h1:e2a+OdqAqWdJIUlc2K8cixif8j5GJhlmCXKUutuosQo=
 github.com/harmony-one/harmony v0.0.0-20191029195210-b3eeed6b4152/go.mod h1:F9/4Jj858j4th+pDeTAR434vS07nVz87TOFLYrpxJpc=
+github.com/harmony-one/harmony v0.0.0-20191106012056-10f5d6274891 h1:B1/1g9IK4KeRmxmBrW7/9oK1xCr5KY1q2Enjo0oc+Ko=
+github.com/harmony-one/harmony v0.0.0-20191106012056-10f5d6274891/go.mod h1:F9/4Jj858j4th+pDeTAR434vS07nVz87TOFLYrpxJpc=
 github.com/harmony-one/taggedrlp v0.1.2 h1:lAHV4UhBE45W+i7duAAWOgaQNUjDIG6rUydz/5Oqric=
 github.com/harmony-one/taggedrlp v0.1.2/go.mod h1:AK7o802368ESS3v4WZI5DzaHv9q0CsdgR9jPVJ6zleg=
 github.com/harmony-one/vdf v0.0.0-20190924175951-620379da8849/go.mod h1:EgNU7X5HLNBBho+OqCm1A1NrpD6xb1SHfi9pMCYaKKw=

--- a/pkg/ledger/nano_S_driver.go
+++ b/pkg/ledger/nano_S_driver.go
@@ -10,6 +10,11 @@ import (
 	"github.com/karalabe/hid"
 )
 
+const (
+	signatureSize int = 65
+	packetSize    int = 255
+)
+
 var DEBUG bool
 
 type hidFramer struct {
@@ -98,7 +103,7 @@ func (hf *hidFramer) Read(p []byte) (int, error) {
 
 
 func (af *apduFramer) Exchange(apdu APDU) ([]byte, error) {
-	if len(apdu.Payload) > 255 {
+	if len(apdu.Payload) > packetSize {
 		panic("APDU payload cannot exceed 255 bytes")
 	}
 	af.hf.Reset()
@@ -203,24 +208,24 @@ func (n *NanoS) GetAddress() (oneAddr string, err error) {
 	return string(pubkey[:]), nil
 }
 
-func (n *NanoS) SignTxn(txn []byte) (sig [65]byte, err error) {
+func (n *NanoS) SignTxn(txn []byte) (sig [signatureSize]byte, err error) {
 	var resp []byte
 
 	var p1 byte = p1More
 	resp, err = n.Exchange(cmdSignTx, p1, p2SignHash, txn)
 	if err != nil {
-		return [65]byte{}, err
+		return [signatureSize]byte{}, err
 	}
 
 	copy(sig[:], resp)
 
 	if copy(sig[:], resp) != len(sig) {
-		return [65]byte{}, errors.New("signature has wrong length")
+		return [signatureSize]byte{}, errors.New("signature has wrong length")
 	}
 	return
 }
 
-func (n *NanoS) SignStaking(stake []byte) (sig [65]byte, err error) {
+func (n *NanoS) SignStaking(stake []byte) (sig [signatureSize]byte, err error) {
 	buf := bytes.NewBuffer(stake)
 	var resp []byte
 
@@ -231,20 +236,20 @@ func (n *NanoS) SignStaking(stake []byte) (sig [65]byte, err error) {
 			p1 = p1First
 		}
 
-		if buf.Len() < 255 {
+		if buf.Len() < packetSize {
 			p2  = p2Finish
 		}
 
-		resp, err = n.Exchange(cmdSignStaking, p1, p2, buf.Next(255))
+		resp, err = n.Exchange(cmdSignStaking, p1, p2, buf.Next(packetSize))
 		if err != nil {
-			return [65]byte{}, err
+			return [signatureSize]byte{}, err
 		}
 	}
 
 	copy(sig[:], resp)
 
 	if copy(sig[:], resp) != len(sig) {
-		return [65]byte{}, errors.New("signature has wrong length")
+		return [signatureSize]byte{}, errors.New("signature has wrong length")
 	}
 	return
 }

--- a/pkg/ledger/nano_S_driver.go
+++ b/pkg/ledger/nano_S_driver.go
@@ -171,11 +171,13 @@ const (
 	cmdSignStaking  = 0x04
 	cmdSignTx       = 0x08
 
-	p1More  = 0x80
+	p1First         = 0x0
+	p1More          = 0x80
 
 	p2DisplayAddress = 0x00
 	p2DisplayHash    = 0x00
 	p2SignHash       = 0x01
+	p2Finish         = 0x02
 )
 
 func (n *NanoS) GetVersion() (version string, err error) {
@@ -219,12 +221,24 @@ func (n *NanoS) SignTxn(txn []byte) (sig [65]byte, err error) {
 }
 
 func (n *NanoS) SignStaking(stake []byte) (sig [65]byte, err error) {
+	buf := bytes.NewBuffer(stake)
 	var resp []byte
 
-	var p1 byte = p1More
-	resp, err = n.Exchange(cmdSignStaking, p1, p2SignHash, stake)
-	if err != nil {
-		return [65]byte{}, err
+	for buf.Len() > 0 {
+		var p1 byte = p1More
+		var p2 byte = p2SignHash
+		if resp == nil {
+			p1 = p1First
+		}
+
+		if buf.Len() < 255 {
+			p2  = p2Finish
+		}
+
+		resp, err = n.Exchange(cmdSignStaking, p1, p2, buf.Next(255))
+		if err != nil {
+			return [65]byte{}, err
+		}
 	}
 
 	copy(sig[:], resp)


### PR DESCRIPTION
1) Updated command line options based on the latest staking message format (Harmony version 110619)
2) Fixed a bug in staking max rate
3) Updated Ledger driver for staking txn to support multiple packets per Txn