### PR TITLE
Add staking tools and add BLS tools

### DIFF
--- a/cmd/subcommands/blockchain.go
+++ b/cmd/subcommands/blockchain.go
@@ -65,6 +65,13 @@ High level information about transaction, like blockNumber, blockHash
 			noLatest = true
 			return request(rpc.Method.GetTransactionReceipt, []interface{}{args[0]})
 		},
+	}, {
+		Use:   "latest-header",
+		Short: "Get the latest header",
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			noLatest = true
+			return request(rpc.Method.GetLatestBlockHeader, []interface{}{})
+		},
 	},
 	}
 	cmdBlockchain.AddCommand(subCommands[:]...)

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	color "github.com/fatih/color"
+	"github.com/fatih/color"
 	"github.com/harmony-one/go-sdk/pkg/account"
 	c "github.com/harmony-one/go-sdk/pkg/common"
 
+	"github.com/harmony-one/go-sdk/pkg/keys"
 	"github.com/harmony-one/go-sdk/pkg/ledger"
 	"github.com/harmony-one/go-sdk/pkg/mnemonic"
 	"github.com/harmony-one/go-sdk/pkg/store"
@@ -18,8 +19,8 @@ import (
 )
 
 const (
-	seedPhraseWarning = ("**Important** write this seed phrase in a safe place, " +
-		"it is the only way to recover your account if you ever forget your password\n\n")
+	seedPhraseWarning = "**Important** write this seed phrase in a safe place, " +
+		"it is the only way to recover your account if you ever forget your password\n\n"
 )
 
 var (
@@ -27,6 +28,7 @@ var (
 	recoverFromMnemonic    bool
 	userProvidesPassphrase bool
 	importPassphrase       string
+	blsFilePath            string
 )
 
 func doubleTakePhrase() string {
@@ -150,7 +152,19 @@ func keysSub() []*cobra.Command {
 		"passphrase to unlock sender's keystore",
 	)
 
-	return []*cobra.Command{add, cmdImportKS, cmdImportSK, cmdExportKS, cmdExportSK, {
+	cmdGenerateBlsKey := &cobra.Command{
+		Use:   "generate-bls-key",
+		Short: "generate bls keys with a requested passphrase",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			passphrase := doubleTakePhrase()
+			return keys.GenBlsKeys(passphrase, blsFilePath)
+		},
+	}
+	cmdGenerateBlsKey.Flags().StringVar(&blsFilePath, "bls-file-path", "",
+		"absolute path of where to save encrypted bls private key")
+
+	// TODO: cleanup these functions...
+	return []*cobra.Command{add, cmdImportKS, cmdImportSK, cmdExportKS, cmdExportSK, cmdGenerateBlsKey, {
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -126,7 +126,7 @@ func handleStakingTransaction(
 func stakingSubCommands() []*cobra.Command {
 
 	subCmdNewValidator := &cobra.Command{
-		Use:   "createvalidator",
+		Use:   "create-validator",
 		Short: "create a new validator",
 		Long: `
 Create a new validator"
@@ -153,7 +153,7 @@ Create a new validator"
 			}
 
 			blsPubKeys := make([]shard.BlsPublicKey, len(stakingBlsPubKeys))
-			for i :=0; i< len(stakingBlsPubKeys); i++ {
+			for i := 0; i < len(stakingBlsPubKeys); i++ {
 				blsPubKey := new(bls.PublicKey)
 				err = blsPubKey.DeserializeHexStr(stakingBlsPubKeys[i])
 				if err != nil {
@@ -233,7 +233,7 @@ Create a new validator"
 	}
 
 	subCmdEditValidator := &cobra.Command{
-		Use:   "editvalidator",
+		Use:   "edit-validator",
 		Short: "edit a validator",
 		Long: `
 Edit an existing validator"
@@ -305,7 +305,6 @@ Edit an existing validator"
 		},
 	}
 
-
 	subCmdEditValidator.Flags().StringVar(&validatorName, "name", "", "validator's name")
 	subCmdEditValidator.Flags().StringVar(&validatorIdentity, "identity", "", "validator's identity")
 	subCmdEditValidator.Flags().StringVar(&validatorWebsite, "website", "", "validator's website")
@@ -315,8 +314,8 @@ Edit an existing validator"
 	subCmdEditValidator.Flags().Float64Var(&minSelfDelegation, "min-self-delegation", 0.0, "minimal self delegation")
 	subCmdEditValidator.Flags().Float64Var(&maxTotalDelegation, "max-total-delegation", 0.0, "maximal total delegation")
 	subCmdEditValidator.Flags().Var(&validatorAddress, "validator-addr", "validator's staking address")
-	subCmdEditValidator.Flags().StringVar(&slotKeyToAdd, "add-bls-key", "","add BLS pubkey to slot")
-	subCmdEditValidator.Flags().StringVar(&slotKeyToRemove, "remove-bls-key", "","remove BLS pubkey from slot")
+	subCmdEditValidator.Flags().StringVar(&slotKeyToAdd, "add-bls-key", "", "add BLS pubkey to slot")
+	subCmdEditValidator.Flags().StringVar(&slotKeyToRemove, "remove-bls-key", "", "remove BLS pubkey from slot")
 
 	subCmdEditValidator.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
 	subCmdEditValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
@@ -431,7 +430,7 @@ Delegating to a validator
 	}
 
 	subCmdCollectRewards := &cobra.Command{
-		Use:   "collectrewards",
+		Use:   "collect-rewards",
 		Short: "collect token rewards",
 		Long: `
 Collect token rewards

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -41,12 +41,33 @@ hmy --node="https://api.s0.b.hmny.io" blockchain transaction-receipt <SOME_TX_HA
 
 %s
 hmy keys import-ks <SOME_ABSOLUTE_PATH_TO_KEYSTORE_JSON>.key
+
+%s
+hmy keys import-private-key <secp256k1_PRIVATE_KEY>
+
+%s
+hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase harmony-one
+
+%s
+hmy keys generate-bls-key --bls-file-path /tmp/file.key
+
+%s
+hmy staking create-validator --amount 10 --validator-addr one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7 \
+    --bls-pubkeys 678ec9670899bf6af85b877058bea4fc1301a5a3a376987e826e3ca150b80e3eaadffedad0fedfa111576fa76ded980c \
+        6757ebfbbc53a167e4c069cdf2beecd1428316306145c8d6d97c6c6babb3ec34e7003b3db8ccfc7d79a412aec7c68c97 \
+    --identity foo --details bar --name baz --max-change-rate 10 --max-rate 10 --max-total-delegation 10 \ 
+    --min-self-delegation 10 --rate 10 --security-contact Leo  --website harmony.one --passphrase=''
+
 `,
-		g("1. Check Balances"),
-		g("2. Check completed transaction"),
-		g("3. List local keys"),
-		g("4. Sending a transaction (add --wait-for-confirm=10 to wait 10 seconds for confirmation)"),
-		g("5. Check a completed transaction receipt"),
-		g("6. Import an existing keystore file"),
+		g("1.  Check Balances"),
+		g("2.  Check completed transaction"),
+		g("3.  List local keys"),
+		g("4.  Sending a transaction (add --wait-for-confirm=10 to wait 10 seconds for confirmation)"),
+		g("5.  Check a completed transaction receipt"),
+		g("6.  Import an existing keystore file"),
+		g("7.  Import a keystore file using a secp256k1 private key"),
+		g("8.  Export a keystore file's secp256k1 private key"),
+		g("9.  Generate a BLS key then encrypt and save the private key to the specified location"),
+		g("10. Create a new validator with a list of BLS keys"),
 	)
 )

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -14,12 +14,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ErrNotAbsPath when keypath not absolute path
-	ErrNotAbsPath   = errors.New("keypath is not absolute path")
-	ErrBadKeyLength = errors.New("Invalid private key (wrong length)")
-)
-
 // ImportFromPrivateKey allows import of an ECDSA private key
 func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 	if name == "" {
@@ -33,7 +27,7 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 		return "", err
 	}
 	if len(privateKeyBytes) != common.Secp256k1PrivateKeyBytesLength {
-		return "", ErrBadKeyLength
+		return "", common.ErrBadKeyLength
 	}
 
 	// btcec.PrivKeyFromBytes only returns a secret key and public key
@@ -72,7 +66,7 @@ func generateName() string {
 // ImportKeyStore imports a keystore along with a password
 func ImportKeyStore(keypath, name, passphrase string) (string, error) {
 	if !path.IsAbs(keypath) {
-		return "", ErrNotAbsPath
+		return "", common.ErrNotAbsPath
 	}
 	keyJSON, readError := ioutil.ReadFile(keypath)
 	if readError != nil {

--- a/pkg/common/values.go
+++ b/pkg/common/values.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"os"
 
 	"github.com/harmony-one/harmony/accounts/keystore"
@@ -19,6 +20,8 @@ var (
 	ScryptP          = keystore.StandardScryptP
 	DebugRPC         = false
 	DebugTransaction = false
+	ErrNotAbsPath    = errors.New("keypath is not absolute path")
+	ErrBadKeyLength  = errors.New("Invalid private key (wrong length)")
 )
 
 func init() {

--- a/pkg/keys/bls.go
+++ b/pkg/keys/bls.go
@@ -1,0 +1,111 @@
+package keys
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/harmony-one/go-sdk/pkg/common"
+	"github.com/harmony-one/harmony/crypto/bls"
+)
+
+func GenBlsKeys(passphrase, filePath string) error {
+	privateKey := bls.RandPrivateKey()
+	publicKey := privateKey.GetPublicKey()
+	publicKeyHex := publicKey.SerializeToHexStr()
+
+	if filePath == "" {
+		cwd, _ := os.Getwd()
+		filePath = fmt.Sprintf("%s/%s.key", cwd, publicKeyHex)
+	}
+	if !path.IsAbs(filePath) {
+		return common.ErrNotAbsPath
+	}
+	privateKeyHex := privateKey.SerializeToHexStr()
+	encryptedPrivateKeyStr, err := encrypt([]byte(privateKeyHex), passphrase)
+	if err != nil {
+		return err
+	}
+	err = writeToFile(filePath, encryptedPrivateKeyStr)
+	if err != nil {
+		return err
+	}
+	out := fmt.Sprintf(`
+{"public-key" : "0x%s", "private-key" : "0x%s", "encrypted-private-key-path" : "%s"}`,
+		publicKeyHex, privateKeyHex, filePath)
+	fmt.Println(common.JSONPrettyFormat(out))
+	return nil
+}
+
+func writeToFile(filename string, data string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.WriteString(file, data)
+	if err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+func createHash(key string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(key))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func encrypt(data []byte, passphrase string) (string, error) {
+	block, _ := aes.NewCipher([]byte(createHash(passphrase)))
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	return hex.EncodeToString(ciphertext), nil
+}
+
+func decrypt(encrypted []byte, passphrase string) (decrypted []byte, err error) {
+	unhexed := make([]byte, hex.DecodedLen(len(encrypted)))
+	if _, err = hex.Decode(unhexed, encrypted); err == nil {
+		if decrypted, err = decryptRaw(unhexed, passphrase); err == nil {
+			return decrypted, nil
+		}
+	}
+	// At this point err != nil, either from hex decode or from decryptRaw.
+	decrypted, binErr := decryptRaw(encrypted, passphrase)
+	if binErr != nil {
+		// Disregard binary decryption error and return the original error,
+		// because our canonical form is hex and not binary.
+		return nil, err
+	}
+	return decrypted, nil
+}
+
+func decryptRaw(data []byte, passphrase string) ([]byte, error) {
+	var err error
+	key := []byte(createHash(passphrase))
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := gcm.NonceSize()
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	return plaintext, err
+}


### PR DESCRIPTION
We can now generate BLS keys (as well as encrypt and save the private BLS key) with the following command:
```
./hmy keys generate-bls-key --bls-file-path /tmp/file.key
```

**Moreover, the following wallet BLS functionalities have been implemented in the CLI:**
* Recover BLS keys from the saved private key file mentioned above. This is compatible with saved BLS keys from the main repo's wallet binary. 
```
./hmy keys recover-bls-key /Users/danielvdm/go/src/github.com/harmony-one/harmony/.hmy/02c8ff0b88f313717bc3a627d2f8bb172ba3ad3bb9ba3ecb8eed4b7c878653d3d4faf769876c528b73f343967f74a917.key --passphrase=''
```
* Encrypt and Save a BLS private key
```
./hmy keys save-bls-key 89f48af29edf71f65a58993a14588d6d1369430a2f208e07e1d1b27be0f30449 --bls-file-path /tmp/test.key
```
* Get public BLS key from private BLS key
```
./hmy keys get-public-bls-key c495e55820920dedb4fda031ee2c0580539f942d966560d2e1724cb9b234692e
```

Also, we can now get the latest header from the blockchain using the following command:
```
./hmy blockchain latest-header
```

Lastly, I changed the staking command syntax to follow convention & updated the cookbook. 