### PR TITLE
Add support for 0x prefix in BLS pub keys

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -155,7 +155,7 @@ Create a new validator"
 			blsPubKeys := make([]shard.BlsPublicKey, len(stakingBlsPubKeys))
 			for i := 0; i < len(stakingBlsPubKeys); i++ {
 				blsPubKey := new(bls.PublicKey)
-				err = blsPubKey.DeserializeHexStr(stakingBlsPubKeys[i])
+				err = blsPubKey.DeserializeHexStr(strings.TrimPrefix(stakingBlsPubKeys[i], "0x"))
 				if err != nil {
 					return err
 				}

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -250,7 +250,7 @@ Edit an existing validator"
 			}
 
 			blsPubKeyRemove := new(bls.PublicKey)
-			err = blsPubKeyRemove.DeserializeHexStr(slotKeyToRemove)
+			err = blsPubKeyRemove.DeserializeHexStr(strings.TrimPrefix(slotKeyToRemove, "0x"))
 			if err != nil {
 				return err
 			}
@@ -259,7 +259,7 @@ Edit an existing validator"
 			shardPubKeyRemove.FromLibBLSPublicKey(blsPubKeyRemove)
 
 			blsPubKeyAdd := new(bls.PublicKey)
-			err = blsPubKeyAdd.DeserializeHexStr(slotKeyToAdd)
+			err = blsPubKeyAdd.DeserializeHexStr(strings.TrimPrefix(slotKeyToAdd, "0x"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
tested both with and without 0x prefix in BLS pub keys.

./hmy staking create-validator --amount 10 --validator-addr one1sl6hku7wxgxnhajrc0a96p6zpea6qr0p0sqajk  --bls-pubkeys 678ec9670899bf6af85b877058bea4fc1301a5a3a376987e826e3ca150b80e3eaadffedad0fedfa111576fa76ded980c,6757ebfbbc53a167e4c069cdf2beecd1428316306145c8d6d97c6c6babb3ec34e7003b3db8ccfc7d79a412aec7c68c97  --identity foo --details bar --name baz --max-change-rate 10 --max-rate 10 --max-total-delegation 10 --min-self-delegation 10 --rate 10 --security-contact Leo --website lol.com --passphrase='harmony-one'
{"transaction-receipt":"0xe9eb9c77e42ef289593de2b537460fcee06c54ec7fab39ba9ba54b5db478fadc"}

 ./hmy staking create-validator --amount 10 --validator-addr one1sl6hku7wxgxnhajrc0a96p6zpea6qr0p0sqajk  --bls-pubkeys 0x678ec9670899bf6af85b877058bea4fc1301a5a3a376987e826e3ca150b80e3eaadffedad0fedfa111576fa76ded980c,0x6757ebfbbc53a167e4c069cdf2beecd1428316306145c8d6d97c6c6babb3ec34e7003b3db8ccfc7d79a412aec7c68c97  --identity foo --details bar --name baz --max-change-rate 10 --max-rate 10 --max-total-delegation 10 --min-self-delegation 10 --rate 10 --security-contact Leo --website lol.com --passphrase='harmony-one'
{"transaction-receipt":"0xe9eb9c77e42ef289593de2b537460fcee06c54ec7fab39ba9ba54b5db478fadc"}