### PR TITLE
updated gaslimit algorithm for staking contracts

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -75,8 +75,13 @@ func createStakingTransaction(nonce uint64, f staking.StakeMsgFulfiller) (*staki
 	gasPrice := big.NewInt(gasPrice)
 	gasPrice = gasPrice.Mul(gasPrice, big.NewInt(denominations.Nano))
 
-	//TODO: modify the gas limit calculation algorithm
-	gasLimit, err := core.IntrinsicGas(nil, false, true)
+	_, payload := f()
+	data, err := rlp.EncodeToBytes(payload)
+	if (err != nil) {
+		return nil, err
+	}
+	
+	gasLimit, err := core.IntrinsicGas(data, false, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For issue https://github.com/harmony-one/go-sdk/issues/50. 

Use the rlp encoded staking data field to get the gaslimit 

gas, err := IntrinsicGas(st.data, contractCreation, homestead)

https://github.com/harmony-one/harmony/blob/2b91eea32d5cd4fbac8dfb7cba37300031407773/core/state_transition.go#L213

