### PR TITLE
adding bls pubkey verification using bls key file and passphrase, als…

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/harmony-one/bls/ffi/go/bls"
+	"github.com/harmony-one/go-sdk/pkg/keys"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -254,6 +255,11 @@ Create a new validator"
 				blsPubKeys[i].FromLibBLSPublicKey(blsPubKey)
 			}
 
+			blsSigs, err := keys.VerifyBLSKeys(stakingBlsPubKeys)
+			if err != nil {
+				return err
+			}
+
 			amountBigInt := big.NewInt(int64(stakingAmount * denominations.Nano))
 			amt := amountBigInt.Mul(amountBigInt, big.NewInt(denominations.Nano))
 
@@ -295,6 +301,7 @@ Create a new validator"
 					minSelfDel,
 					maxTotalDel,
 					blsPubKeys,
+					blsSigs,
 					amt,
 				}
 			}
@@ -372,6 +379,11 @@ Edit an existing validator"
 			shardPubKeyAdd := shard.BlsPublicKey{}
 			shardPubKeyAdd.FromLibBLSPublicKey(blsPubKeyAdd)
 
+			sigBls, err := keys.VerifyBLS(slotKeyToAdd)
+			if err != nil {
+				return err
+			}
+
 			minSelfDelegationBigInt := big.NewInt(int64(minSelfDelegation * denominations.Nano))
 			minSelfDel := minSelfDelegationBigInt.Mul(minSelfDelegationBigInt, big.NewInt(denominations.Nano))
 
@@ -403,6 +415,7 @@ Edit an existing validator"
 					maxTotalDel,
 					&shardPubKeyRemove,
 					&shardPubKeyAdd,
+					sigBls,
 				}
 
 			}

--- a/pkg/keys/bls.go
+++ b/pkg/keys/bls.go
@@ -20,6 +20,7 @@ import (
 	"github.com/harmony-one/harmony/crypto/bls"
 	"github.com/harmony-one/harmony/crypto/hash"
 	"github.com/harmony-one/harmony/shard"
+	"github.com/harmony-one/harmony/staking/types"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -174,7 +175,7 @@ func VerifyBLS(blsPubKey string) (shard.BlsSignature, error) {
 		return sig, errors.New("bls key could not be verified")
 	}
 
-	messageBytes := []byte("harmony-one")
+	messageBytes := []byte(types.BlsVerificationStr)
 	msgHash := hash.Keccak256(messageBytes)
 	signature := privateKey.SignHash(msgHash[:])
 


### PR DESCRIPTION
adding bls pubkey verification using bls key file and passphrase, also sending bls signatures for backend to verify
* create and edit validator commands will require bls key file in the current working directory or input from the user along with passphrase to decrypt the file.
* errors will be throws if key cannot be decrypted or passphrase fails to authenticate
* on success, the signatures for each bls public key in the create validator and slot key added in the edit validator is sent to backend for verification.
* corresponding code for backend is available 