### PR TITLE
[#73] Fix logic for sanity check on create-validator fields

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -163,8 +163,9 @@ func delegationAmountSanityCheck(minSelfDelegation numeric.Dec, maxTotalDelegati
 	}
 
 	// Amount must be >= MinSelfDelegation
-	if amount != nil &&
-		(amount.GT(maxTotalDelegation) || amount.LT(minSelfDelegation)) {
+	if amount != nil && amount.GT(minSelfDelegation) &&
+		(amount.Equal(numeric.ZeroDec()) ||
+		(!amount.Equal(numeric.ZeroDec()) && amount.LT(maxTotalDelegation))) {
 		return errInvalidSelfDelegation
 	}
 


### PR DESCRIPTION
Amount is less than max (if max is not 0) and greater than min