### PR TITLE
Nonce control fix.

### DIFF
--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/harmony-one/go-sdk/pkg/address"
+	"github.com/harmony-one/go-sdk/pkg/rpc"
 	"github.com/harmony-one/harmony/core/types"
 )
 
@@ -17,6 +18,19 @@ func NewTransaction(
 	data []byte) *Transaction {
 	// types.New
 	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount, gasLimit, gasPrice, data)
+}
+
+func GetNextNonce(addr string, messenger rpc.T) uint64 {
+	transactionCountRPCReply, err :=
+		messenger.SendRPC(rpc.Method.GetTransactionCount, []interface{}{address.Parse(addr), "latest"})
+
+	if err != nil {
+		return 0
+	}
+
+	transactionCount, _ := transactionCountRPCReply["result"].(string)
+	n, _ := big.NewInt(0).SetString(transactionCount[2:], 16)
+	return n.Uint64()
 }
 
 func IsValid(tx *Transaction) bool {


### PR DESCRIPTION
For a regular transaction, if no nonce option is provided, it should now correctly set the next nonce (previously underflowed to max val of `uint64`). Moreover, one could only set the nonce to at most the max of `int64`. This PR should now allow one to set the nonce to up to the max of `uint64`.