### PR TITLE
remove 0x from public-key/private-key display part of generate-bls-key

### DIFF
--- a/pkg/keys/bls.go
+++ b/pkg/keys/bls.go
@@ -46,7 +46,7 @@ func GenBlsKeys(passphrase, filePath string) error {
 		return err
 	}
 	out := fmt.Sprintf(`
-{"public-key" : "0x%s", "private-key" : "0x%s", "encrypted-private-key-path" : "%s"}`,
+{"public-key" : "%s", "private-key" : "%s", "encrypted-private-key-path" : "%s"}`,
 		publicKeyHex, privateKeyHex, filePath)
 	fmt.Println(common.JSONPrettyFormat(out))
 	return nil


### PR DESCRIPTION
It is confusing to display public-key and private-key with `0x` when user generates bls keys using `hmy keys generate-bls-key` command. Hence, removing it.