### PR TITLE
Add support for removing an account from the keystore

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -105,6 +105,19 @@ func keysSub() []*cobra.Command {
 	)
 	cmdAdd.Flags().BoolVar(&userProvidesPassphrase, "use-own-passphrase", false, ppPrompt)
 
+	cmdRemove := &cobra.Command{
+		Use:   "remove <ACCOUNT_NAME>",
+		Short: "Remove a key from the keystore",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !store.DoesNamedAccountExist(args[0]) {
+				return fmt.Errorf("account %s doesn't exist", args[0])
+			}
+			account.RemoveAccount(args[0])
+			return nil
+		},
+	}
+
 	cmdMnemonic := &cobra.Command{
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
@@ -230,7 +243,7 @@ func keysSub() []*cobra.Command {
 		},
 	}
 
-	return []*cobra.Command{cmdList, cmdLocation, cmdAdd, cmdMnemonic, cmdImportKS, cmdImportSK,
+	return []*cobra.Command{cmdList, cmdLocation, cmdAdd, cmdRemove, cmdMnemonic, cmdImportKS, cmdImportSK,
 		cmdExportKS, cmdExportSK, cmdGenerateBlsKey, cmdRecoverBlsKey, cmdSaveBlsKey, GetPublicBlsKey}
 }
 

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -110,10 +110,10 @@ func keysSub() []*cobra.Command {
 		Short: "Remove a key from the keystore",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !store.DoesNamedAccountExist(args[0]) {
-				return fmt.Errorf("account %s doesn't exist", args[0])
+			if err := account.RemoveAccount(args[0]); err != nil {
+				return err
 			}
-			account.RemoveAccount(args[0])
+
 			return nil
 		},
 	}

--- a/pkg/account/account_test.go
+++ b/pkg/account/account_test.go
@@ -1,0 +1,45 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/harmony-one/go-sdk/pkg/store"
+)
+
+func TestAccountGetsRemoved(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Expected bool
+	}{
+		{"foobar", false},
+	}
+
+	for _, test := range tests {
+		acc := Creation{
+			Name:            test.Name,
+			Passphrase:      "",
+			Mnemonic:        "",
+			HdAccountNumber: nil,
+			HdIndexNumber:   nil,
+		}
+
+		err := CreateNewLocalAccount(&acc)
+
+		if err != nil {
+			t.Errorf(`RemoveAccount("%s") failed to create keystore account %v`, test.Name, err)
+		}
+
+		exists := store.DoesNamedAccountExist(test.Name)
+
+		if !exists {
+			t.Errorf(`RemoveAccount("%s") account should exist - but it can't be found`, test.Name)
+		}
+
+		RemoveAccount(test.Name)
+		exists = store.DoesNamedAccountExist(test.Name)
+
+		if exists != test.Expected {
+			t.Errorf(`RemoveAccount("%s") returned %v, expected %v`, test.Name, exists, test.Expected)
+		}
+	}
+}

--- a/pkg/account/removal.go
+++ b/pkg/account/removal.go
@@ -1,0 +1,27 @@
+package account
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/harmony-one/go-sdk/pkg/common"
+	"github.com/harmony-one/go-sdk/pkg/store"
+	"github.com/mitchellh/go-homedir"
+)
+
+// RemoveAccount - removes an account from the keystore
+func RemoveAccount(name string) error {
+	accountExists := store.DoesNamedAccountExist(name)
+
+	if !accountExists {
+		return fmt.Errorf("account %s doesn't exist", name)
+	}
+
+	uDir, _ := homedir.Dir()
+	hmyCLIDir := path.Join(uDir, common.DefaultConfigDirName, common.DefaultConfigAccountAliasesDirName)
+	accountDir := fmt.Sprintf("%s/%s", hmyCLIDir, name)
+	os.RemoveAll(accountDir)
+
+	return nil
+}


### PR DESCRIPTION
This PR adds support for removing a named account from the keystore.

The PR adds a new subcommand to the "keys" command, e.g:
`./hmy keys remove foobar`

A unit test is also included, run it using `cd pkg/account && go test . && cd ../..`