### PR TITLE
[harmony #2057] Enable Atto precision transactions using the CLI

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -71,8 +71,7 @@ var (
 )
 
 func createStakingTransaction(nonce uint64, f staking.StakeMsgFulfiller) (*staking.StakingTransaction, error) {
-	gasPrice := big.NewInt(gasPrice)
-	gasPrice = gasPrice.Mul(gasPrice, big.NewInt(denominations.Nano))
+	gPrice := big.NewInt(int64(gasPrice))
 
 	_, payload := f()
 	data, err := rlp.EncodeToBytes(payload)
@@ -85,7 +84,7 @@ func createStakingTransaction(nonce uint64, f staking.StakeMsgFulfiller) (*staki
 		return nil, err
 	}
 
-	stakingTx, err := staking.NewStakingTransaction(nonce, gasLimit, gasPrice, f)
+	stakingTx, err := staking.NewStakingTransaction(nonce, gasLimit, gPrice, f)
 	return stakingTx, err
 }
 
@@ -361,7 +360,8 @@ Create a new validator"
 		&stakingBlsPubKeys, "bls-pubkeys", []string{}, "validator's list of public BLS key addresses",
 	)
 	subCmdNewValidator.Flags().StringVar(&stakingAmount, "amount", "0.0", "staking amount")
-	subCmdNewValidator.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdNewValidator.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdNewValidator.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	subCmdNewValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdNewValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdNewValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
@@ -485,7 +485,8 @@ Create a new validator"
 	subCmdEditValidator.Flags().StringVar(&slotKeyToAdd, "add-bls-key", "", "add BLS pubkey to slot")
 	subCmdEditValidator.Flags().StringVar(&slotKeyToRemove, "remove-bls-key", "", "remove BLS pubkey from slot")
 
-	subCmdEditValidator.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdEditValidator.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdEditValidator.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	subCmdEditValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdEditValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdEditValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
@@ -544,7 +545,8 @@ Delegating to a validator
 	subCmdDelegate.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
 	subCmdDelegate.Flags().Var(&validatorAddress, "validator-addr", "validator's address")
 	subCmdDelegate.Flags().StringVar(&stakingAmount, "amount", "0.0", "staking amount")
-	subCmdDelegate.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdDelegate.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdDelegate.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	subCmdDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
@@ -600,7 +602,8 @@ Delegating to a validator
 	subCmdUnDelegate.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
 	subCmdUnDelegate.Flags().Var(&validatorAddress, "validator-addr", "source validator's address")
 	subCmdUnDelegate.Flags().StringVar(&stakingAmount, "amount", "0.0", "staking amount")
-	subCmdUnDelegate.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdUnDelegate.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdUnDelegate.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	subCmdUnDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdUnDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdUnDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
@@ -649,7 +652,8 @@ Collect token rewards
 	}
 
 	subCmdCollectRewards.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
-	subCmdCollectRewards.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdCollectRewards.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	subCmdCollectRewards.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	subCmdCollectRewards.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for tx")
 	subCmdCollectRewards.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdCollectRewards.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/harmony-one/go-sdk/pkg/transaction"
 	"github.com/harmony-one/go-sdk/pkg/validation"
 	"github.com/harmony-one/harmony/accounts"
+	common2 "github.com/harmony-one/go-sdk/pkg/common"
 
 	"github.com/spf13/cobra"
 )
@@ -19,7 +20,7 @@ import (
 var (
 	fromAddress oneAddress
 	toAddress   oneAddress
-	amount      float64
+	amount      string
 	fromShardID uint32
 	toShardID   uint32
 	confirmWait uint32
@@ -27,7 +28,8 @@ var (
 	dryRun      bool
 	unlockP     string
 	inputNonce  string
-	gasPrice    int64
+	gasPrice    uint64
+	gasLimit    int
 )
 
 func handlerForShard(senderShard uint32, node string) (*rpc.HTTPMessenger, error) {
@@ -111,10 +113,16 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 				return err
 			}
 
+			amt, err := common2.NewDecFromString(amount)
+			if err != nil {
+				return err
+			}
+
 			if transactionFailure := ctrlr.ExecuteTransaction(
 				toAddress.String(),
 				"",
-				amount, gasPrice, nonce,
+				amt, nonce,
+				gasPrice, gasLimit,
 				int(fromShardID),
 				int(toShardID),
 			); transactionFailure != nil {
@@ -137,8 +145,9 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 	cmdTransfer.Flags().Var(&fromAddress, "from", "sender's one address, keystore must exist locally")
 	cmdTransfer.Flags().Var(&toAddress, "to", "the destination one address")
 	cmdTransfer.Flags().BoolVar(&dryRun, "dry-run", false, "do not send signed transaction")
-	cmdTransfer.Flags().Float64Var(&amount, "amount", 0.0, "amount")
-	cmdTransfer.Flags().Int64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	cmdTransfer.Flags().StringVar(&amount, "amount", "0", "amount")
+	cmdTransfer.Flags().Uint64Var(&gasPrice, "gas-price", 1, "gas price to pay")
+	cmdTransfer.Flags().IntVar(&gasLimit, "gas-limit", 21000, "gas limit")
 	cmdTransfer.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for tx")
 	cmdTransfer.Flags().Uint32Var(&fromShardID, "from-shard", 0, "source shard id")
 	cmdTransfer.Flags().Uint32Var(&toShardID, "to-shard", 0, "target shard id")

--- a/pkg/common/numeric.go
+++ b/pkg/common/numeric.go
@@ -2,10 +2,47 @@ package common
 
 import (
 	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/harmony-one/harmony/common/denominations"
+	"github.com/harmony-one/harmony/numeric"
+)
+
+var (
+	pattern, _ = regexp.Compile("[0-9]+\\.{0,1}[0-9]*e-{0,1}[0-9]+")
 )
 
 func NormalizeAmount(value *big.Int) *big.Int {
 	return value.Div(value, big.NewInt(denominations.Nano))
+}
+
+func Pow(base numeric.Dec, exp int) numeric.Dec {
+	if (exp < 0) {
+		return Pow(numeric.NewDec(1).Quo(base), -exp)
+	}
+	result := numeric.NewDec(1)
+	for {
+		if (exp % 2 == 1) {
+			result = result.Mul(base)
+		}
+		exp = exp >> 1
+		if (exp == 0) {
+			break
+		}
+		base = base.Mul(base)
+	}
+	return result
+}
+
+func NewDecFromString (i string) (numeric.Dec, error) {
+	if pattern.FindString(i) != "" {
+		tokens := strings.Split(i, "e")
+		a, _ := numeric.NewDecFromStr(tokens[0])
+		b, _ := strconv.Atoi(tokens[1])
+		return a.Mul(Pow(numeric.NewDec(10), b)), nil
+	} else {
+		return numeric.NewDecFromStr(i)
+	}
 }

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -6,18 +6,19 @@ import (
 	"github.com/harmony-one/go-sdk/pkg/address"
 	"github.com/harmony-one/go-sdk/pkg/rpc"
 	"github.com/harmony-one/harmony/core/types"
+	"github.com/harmony-one/harmony/numeric"
 )
 
 type Transaction = types.Transaction
 
 func NewTransaction(
-	nonce, gasLimit uint64,
+	nonce, gasLimit, gasPrice uint64,
 	to address.T,
 	shardID, toShardID uint32,
-	amount, gasPrice *big.Int,
+	amount numeric.Dec,
 	data []byte) *Transaction {
 	// types.New
-	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount, gasLimit, gasPrice, data)
+	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount.TruncateInt(), gasLimit, big.NewInt(int64(gasPrice)), data)
 }
 
 func GetNextNonce(addr string, messenger rpc.T) uint64 {


### PR DESCRIPTION
* Replace big.Int with numeric.Dec to enable enough precision for Atto transactions
* Check transaction amount + gas price when verifying existing balance before transactions
* Enable scientific notation input
* Enable user to input desired gas-price & gas-limit
* Set default gas to 1 Gwei
* Calculate gas-price based on gas-limit

Staking transaction is currently untested.