### PR TITLE
Encrypt imported keystore file with given passphrase

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -128,7 +128,7 @@ func keysSub() []*cobra.Command {
 	}
 
 	cmdImportKS := &cobra.Command{
-		Use:   "import-ks <ABSOLUTE_PATH_KEYSTORE> [ACCOUNT_NAME]",
+		Use:   "import-ks <KEYSTORE_FILE_PATH> [ACCOUNT_NAME]",
 		Args:  cobra.RangeArgs(1, 2),
 		Short: "Import an existing keystore key",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -3,7 +3,7 @@ package account
 import (
 	"encoding/hex"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -65,8 +65,9 @@ func generateName() string {
 
 // ImportKeyStore imports a keystore along with a password
 func ImportKeyStore(keypath, name, passphrase string) (string, error) {
-	if !path.IsAbs(keypath) {
-		return "", common.ErrNotAbsPath
+	keypath, err := filepath.Abs(keypath)
+	if err != nil {
+		return "", err
 	}
 	keyJSON, readError := ioutil.ReadFile(keypath)
 	if readError != nil {
@@ -76,7 +77,7 @@ func ImportKeyStore(keypath, name, passphrase string) (string, error) {
 		name = generateName() + "-imported"
 	}
 	ks := store.FromAccountName(name)
-	_, err := ks.Import(keyJSON, passphrase, common.DefaultPassphrase)
+	_, err = ks.Import(keyJSON, passphrase, passphrase)
 	if err != nil {
 		return "", errors.Wrap(err, "could not import")
 	}


### PR DESCRIPTION
* Use given passphrase when encrypting imported ks
* Allow the use of relative paths
* Update help doc for `keys import-ks`