### PR TITLE
Address issue #119 & #120 and make batched transaction more general + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ invoke the following command to see the most command usages of `hmy`
 ```
 $ hmy cookbook
 
+Cookbook of Usage
+
 Note:
 
 1) Every subcommand recognizes a '--help' flag
-2) These examples use shard 1 of testnet as argument for --node
+2) If a passphrase is used by a subcommand, one can enter their own passphrase interactively
+   with the --passphrase option. Alternatively, one can pass their own passphrase via a file
+   using the --passphrase-file option. If no passphrase option is selected, the default
+   passphrase of '' is used.
+3) These examples use shard 1 of testnet as argument for --node
 
 Examples:
 
@@ -54,63 +60,188 @@ hmy --node="https://api.s1.p.hmny.io" blockchain transaction-by-hash <SOME_TX_HA
 3.  List local account keys
 hmy keys list
 
-4.  Sending a transaction (add --wait-for-confirm=10 to wait 10 seconds for confirmation)
+4.  Sending a transaction (add `--wait-for-confirm=10` to wait 10 seconds for confirmation)
 hmy --node="https://api.s1.p.hmny.io/" transfer \
     --from one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw \
     --to one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6 \
     --from-shard 0 --to-shard 1 --amount 200
 
-5.  Check a completed transaction receipt
+5.  Sending a batch of transactions as dictated from a file (the `--wait-for-confirm` and `--dry-run` options still apply)
+hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
+
+    Example of JSON file format:
+      [
+        {
+          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+          "from-shard" : "0",
+          "to-shard": "0",
+          "amount": "1",
+          "passphrase-string": "",
+          "nonce": "-1",
+          "stop-on-error": true
+        },
+        {
+          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+          "from-shard" : "0",
+          "to-shard": "0",
+          "amount": "1",
+          "passphrase-file": "./pw.txt"
+        }
+      ]
+
+6.  Check a completed transaction receipt
 hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
-6.  Import an account using the mnemonic. Prompts the user to give the mnemonic.
+7.  Import an account using the mnemonic. Prompts the user to give the mnemonic.
 hmy keys add --recover
 
-7.  Import an existing keystore file
-hmy keys import-ks <SOME_ABSOLUTE_PATH_TO_KEYSTORE_JSON>.key
+8.  Import an existing keystore file
+hmy keys import-ks <PATH_TO_KEYSTORE_JSON>.key
 
-8.  Import a keystore file using a secp256k1 private key
+9.  Import a keystore file using a secp256k1 private key
 hmy keys import-private-key <secp256k1_PRIVATE_KEY>
 
-9.  Export a keystore file's secp256k1 private key
-hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase <YOUR_PASSWORD>
+10.  Export a keystore file's secp256k1 private key
+hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
 
-10. Generate a BLS key then encrypt and save the private key to the specified location. Prompts user to give a password to lock the file.
+11. Generate a BLS key then encrypt and save the private key to the specified location.
 hmy keys generate-bls-key --bls-file-path /tmp/file.key
 
-11. Create a new validator with a list of BLS keys
+12. Create a new validator with a list of BLS keys
 hmy --node="https://api.s1.p.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
-    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase <YOUR_PASSWORD>
+    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase
 
-12. Edit an existing validator
+13. Edit an existing validator
 hmy --node="https://api.s1.p.hmny.io" staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
-    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase <YOUR_PASSWORD>
+    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase
 
-13. Delegate an amount to a validator
+14. Delegate an amount to a validator
 hmy --node="https://api.s1.p.hmny.io" staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase <YOUR_PASSWORD>
+    --amount 10 --passphrase
 
-14. Undelegate to a validator
+15. Undelegate to a validator
 hmy --node="https://api.s1.p.hmny.io" staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase <YOUR_PASSWORD>
+    --amount 10 --passphrase
 
-15. Collect block rewards as a delegator
+16. Collect block rewards as a delegator
 hmy --node="https://api.s1.p.hmny.io" staking collect-rewards \
-    --delegator-addr <SOME_ONE_ADDRESS> --passphrase <YOUR_PASSWORD>
+    --delegator-addr <SOME_ONE_ADDRESS> --passphrase
 
-16. Check active validators
+17. Check active validators
 hmy --node="https://api.s1.p.hmny.io" blockchain validator all-active
 
-17. Check in-memory record of failed staking transactions
+18. Check in-memory record of failed staking transactions
 hmy failures staking
+```
 
+# Sending batched transactions
+
+One may find it useful to send a batch of transaction with 1 instance of the binary.
+To do this, one can specify a JSON file with the `transaction` subcommand to dictate a batch of transaction to send
+off **in sequential order**. 
+
+Example:
+```
+hmy --node="https://api.s1.p.hmny.io/" transfer --file ./batchTransactions.json
+``` 
+
+> Note that the `--wait-for-confirm` and `--dry-run` options still apply when sending batched transactions
+
+## Transfer JSON file format
+The JSON file will be a JSON array where each element has the following attributes:
+
+| Key                 | Value-type | Value-description|
+| :------------------:|:----------:| :----------------|
+| `from`              | string     | [**Required**] Sender's one address, must have key in keystore. |
+| `to`                | string     | [**Required**] The receivers one address. |
+| `amount`            | string     | [**Required**] The amount to send in $ONE. |
+| `from-shard`        | string     | [**Required**] The source shard. |
+| `to-shard`          | string     | [**Required**] The destination shard. |
+| `passphrase-file`   | string     | [*Optional*] The file path to file containing the passphrase in plain text. If none is provided, check for passphrase string. |
+| `passphrase-string` | string     | [*Optional*] The passphrase as a string in plain text. If none is provided, passphrase is ''. |
+| `nonce`             | string     | [*Optional*] The nonce of a specific transaction, default uses nonce from blockchain. |
+| `gas-price`         | string     | [*Optional*] The gas price to pay in NANO (1e-9 of $ONE), default is 1. |
+| `gas-limit`         | string     | [*Optional*] The gas limit, default is 21000. |
+| `stop-on-error`     | boolean    | [*Optional*] If true, stop sending transactions if an error occurred, default is false. |
+
+Example of JSON file:
+
+```json
+[
+  {
+    "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+    "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+    "from-shard" : "0",
+    "to-shard": "0",
+    "amount": "1",
+    "passphrase-string": "",
+    "nonce": "35",
+    "stop-on-error": true
+  },
+  {
+    "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+    "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+    "from-shard" : "0",
+    "to-shard": "0",
+    "amount": "1",
+    "passphrase-file": "./pw.txt",
+    "gas-price": "1",
+    "gas-limit": "21000"
+  }
+]
+```
+
+## Batched transaction response format
+
+The return will be a JSON array where each element is a transaction log.
+The transaction log has the following attributes:
+
+| Key                   | Value-type  | Value-description|
+| :--------------------:|:-----------:| :----------------|
+| `transaction-receipt` | string      | The transaction hash/receipt if the CLI signed **and sent** a transaction, otherwise this key will not exist |
+| `transaction`         | JSON Object | The transaction parameters if `--dry-run` is toggled, otherwise this key will not exist. |
+| `blockchain-receipt`  | JSON Object | The transaction receipt from the blockchain if `wait-for-confirm` is > 0, otherwise this key will not exist. |
+| `raw-transaction`     | string      | The raw bytes in hex of a sighed transaction if `--dry-run` is toggled, otherwise this key will not exist |
+| `errors`              | JSON Array  | A JSON array of strings describing **any** error that occurred during the execution of a transaction. If no errors, this key will not exist. |
+| `time-signed-utc`     | string      | The time in UTC as a string of roughly when the transaction was signed. If no signed transaction, this key will not exist. |
+
+Example of returned JSON Array:
+```json
+[
+  {
+    "errors": [
+      "[2020-01-22 22:01:10.819406] strconv.ParseUint: parsing \"-1\": invalid syntax"
+    ]
+  },
+  {
+    "transaction-receipt": "0xf1706080ea9ac210ee2c12c69fb310be5a5da99582b7c783e2f741a3536abbfd",
+    "blockchain-receipt": {
+      "blockHash": "0xe6de09f4e0ca351257d301a50b4e2ca82646473dc1c4302b570bfab17d421850",
+      "blockNumber": "0xb71",
+      "contractAddress": null,
+      "cumulativeGasUsed": "0x5208",
+      "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+      "gasUsed": "0x5208",
+      "logs": [],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "shardID": 0,
+      "status": "0x1",
+      "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+      "transactionHash": "0xf1706080ea9ac210ee2c12c69fb310be5a5da99582b7c783e2f741a3536abbfd",
+      "transactionIndex": "0x0"
+    },
+    "time-signed-utc": "2020-01-22 22:01:11.468407"
+  }
+]
 ```
 
 # Debugging

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -64,6 +64,7 @@ func getPassphrase() (string, error) {
 		if string(repeatPass) != string(pass) {
 			return "", errors.New("passphrase does not match")
 		}
+		fmt.Println("") // provide feedback when passphrase is entered.
 		return string(repeatPass), nil
 	} else {
 		return c.DefaultPassphrase, nil

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -37,6 +37,9 @@ var (
 	)
 )
 
+// getPassphrase fetches the correct passphrase depending on if a file is available to
+// read from or if the user wants to enter in their own passphrase. Otherwise, just use
+// the default passphrase.
 func getPassphrase() (string, error) {
 	if passphraseFilePath != "" {
 		if _, err := os.Stat(passphraseFilePath); os.IsNotExist(err) {

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 
 	"github.com/fatih/color"
@@ -27,20 +29,42 @@ var (
 	quietImport            bool
 	recoverFromMnemonic    bool
 	userProvidesPassphrase bool
-	importPassphrase       string
+	passphraseFilePath     string
+	passphrase             string
 	blsFilePath            string
+	ppPrompt               = fmt.Sprintf(
+		"prompt for passphrase, otherwise use default passphrase: \"`%s`\"", c.DefaultPassphrase,
+	)
 )
 
-func doubleTakePhrase() string {
-	fmt.Println("Enter passphrase:")
-	pass, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println("Repeat the passphrase:")
-	repeatPass, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
-	if string(repeatPass) != string(pass) {
-		fmt.Println("Passphrases do not match")
-		os.Exit(-1)
+func getPassphrase() (string, error) {
+	if passphraseFilePath != "" {
+		if _, err := os.Stat(passphraseFilePath); os.IsNotExist(err) {
+			return "", errors.New(fmt.Sprintf("passphrase file not found at `%s`", passphraseFilePath))
+		}
+		dat, err := ioutil.ReadFile(passphraseFilePath)
+		if err != nil {
+			return "", err
+		}
+		return string(dat), nil
+	} else if userProvidesPassphrase {
+		fmt.Println("Enter passphrase:")
+		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
+		fmt.Println("Repeat the passphrase:")
+		repeatPass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return "", err
+		}
+		if string(repeatPass) != string(pass) {
+			return "", errors.New("passphrase does not match")
+		}
+		return string(repeatPass), nil
+	} else {
+		return c.DefaultPassphrase, nil
 	}
-	return string(repeatPass)
 }
 
 func keysSub() []*cobra.Command {
@@ -74,11 +98,14 @@ func keysSub() []*cobra.Command {
 			if store.DoesNamedAccountExist(args[0]) {
 				return fmt.Errorf("account %s already exists", args[0])
 			}
-			passphrase := c.DefaultPassphrase
-			if userProvidesPassphrase {
-				passphrase = doubleTakePhrase()
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
 			}
-			t := account.Creation{args[0], passphrase, "", nil, nil}
+			acc := account.Creation{
+				Name:       args[0],
+				Passphrase: passphrase,
+			}
 			if recoverFromMnemonic {
 				fmt.Println("Enter mnemonic to recover keys from")
 				scanner := bufio.NewScanner(os.Stdin)
@@ -87,23 +114,21 @@ func keysSub() []*cobra.Command {
 				if !bip39.IsMnemonicValid(m) {
 					return mnemonic.InvalidMnemonic
 				}
-				t.Mnemonic = m
+				acc.Mnemonic = m
 			}
-			if err := account.CreateNewLocalAccount(&t); err != nil {
+			if err := account.CreateNewLocalAccount(&acc); err != nil {
 				return err
 			}
 			if !recoverFromMnemonic {
 				color.Red(seedPhraseWarning)
-				fmt.Println(t.Mnemonic)
+				fmt.Println(acc.Mnemonic)
 			}
 			return nil
 		},
 	}
 	cmdAdd.Flags().BoolVar(&recoverFromMnemonic, "recover", false, "create keys from a mnemonic")
-	ppPrompt := fmt.Sprintf(
-		"prompt user for passphrase, otherwise default passphrase: \"`%s`\"", c.DefaultPassphrase,
-	)
-	cmdAdd.Flags().BoolVar(&userProvidesPassphrase, "use-own-passphrase", false, ppPrompt)
+	cmdAdd.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdAdd.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	cmdRemove := &cobra.Command{
 		Use:   "remove <ACCOUNT_NAME>",
@@ -113,7 +138,6 @@ func keysSub() []*cobra.Command {
 			if err := account.RemoveAccount(args[0]); err != nil {
 				return err
 			}
-
 			return nil
 		},
 	}
@@ -136,30 +160,33 @@ func keysSub() []*cobra.Command {
 			if len(args) == 2 {
 				userName = args[1]
 			}
-			name, err := account.ImportKeyStore(args[0], userName, importPassphrase)
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
+			name, err := account.ImportKeyStore(args[0], userName, passphrase)
 			if !quietImport && err == nil {
 				fmt.Printf("Imported keystore given account alias of `%s`\n", name)
 			}
 			return err
 		},
 	}
-	importP := `passphrase of key being imported, default assumes ""`
-	cmdImportKS.Flags().StringVar(&importPassphrase, "passphrase", "", importP)
+	cmdImportKS.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdImportKS.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 	cmdImportKS.Flags().BoolVar(&quietImport, "quiet", false, "do not print out imported account name")
-	cmdImportKS.MarkFlagRequired("passphrase")
 
 	cmdImportSK := &cobra.Command{
 		Use:   "import-private-key <secp256k1_PRIVATE_KEY> [ACCOUNT_NAME]",
 		Short: "Import an existing keystore key (only accept secp256k1 private keys)",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			passphrase := c.DefaultPassphrase
-			if userProvidesPassphrase {
-				passphrase = doubleTakePhrase()
-			}
 			userName := ""
 			if len(args) == 2 {
 				userName = args[1]
+			}
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
 			}
 			name, err := account.ImportFromPrivateKey(args[0], userName, passphrase)
 			if !quietImport && err == nil {
@@ -175,64 +202,78 @@ func keysSub() []*cobra.Command {
 		Short: "Export the secp256k1 private key",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := account.ExportPrivateKey(args[0], unlockP)
-			return err
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
+			return account.ExportPrivateKey(args[0], passphrase)
 		},
 	}
-	cmdExportSK.Flags().StringVar(&unlockP,
-		"passphrase", c.DefaultPassphrase,
-		"passphrase to unlock sender's keystore",
-	)
+	cmdExportSK.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdExportSK.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	cmdExportKS := &cobra.Command{
 		Use:   "export-ks <ACCOUNT_ADDRESS>",
 		Short: "Export the keystore file contents",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := account.ExportKeystore(args[0], unlockP)
-			return err
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
+			return account.ExportKeystore(args[0], passphrase)
 		},
 	}
-	cmdExportKS.Flags().StringVar(&unlockP,
-		"passphrase", c.DefaultPassphrase,
-		"passphrase to unlock sender's keystore",
-	)
+	cmdExportKS.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdExportKS.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	cmdGenerateBlsKey := &cobra.Command{
 		Use:   "generate-bls-key",
 		Short: "Generate bls keys then encrypt and save the private key with a requested passphrase",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			passphrase := doubleTakePhrase()
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
 			return keys.GenBlsKeys(passphrase, blsFilePath)
 		},
 	}
 	cmdGenerateBlsKey.Flags().StringVar(&blsFilePath, "bls-file-path", "",
 		"absolute path of where to save encrypted bls private key")
+	cmdGenerateBlsKey.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdGenerateBlsKey.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	cmdRecoverBlsKey := &cobra.Command{
 		Use:   "recover-bls-key <ABSOLUTE_PATH_BLS_KEY>",
 		Short: "Recover bls keys from an encrypted bls key file",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return keys.RecoverBlsKeyFromFile(unlockP, args[0])
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
+			return keys.RecoverBlsKeyFromFile(passphrase, args[0])
 		},
 	}
-	cmdRecoverBlsKey.Flags().StringVar(&unlockP,
-		"passphrase", c.DefaultPassphrase,
-		"passphrase to unlock sender's keystore",
-	)
+	cmdRecoverBlsKey.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdRecoverBlsKey.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	cmdSaveBlsKey := &cobra.Command{
 		Use:   "save-bls-key <PRIVATE_BLS_KEY>",
 		Short: "Encrypt and save the bls private key with a requested passphrase",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			passphrase := doubleTakePhrase()
+			passphrase, err := getPassphrase()
+			if err != nil {
+				return err
+			}
 			return keys.SaveBlsKey(passphrase, blsFilePath, args[0])
 		},
 	}
 	cmdSaveBlsKey.Flags().StringVar(&blsFilePath, "bls-file-path", "",
 		"absolute path of where to save encrypted bls private key")
+	cmdSaveBlsKey.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdSaveBlsKey.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	GetPublicBlsKey := &cobra.Command{
 		Use:   "get-public-bls-key <PRIVATE_BLS_KEY>",

--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -29,7 +29,7 @@ var (
 	noPrettyOutput  bool
 	node            string
 	keyStoreDir     string
-	filepath        string
+	givenFilePath   string
 	request         = func(method string, params []interface{}) error {
 		if !noLatest {
 			params = append(params, "latest")
@@ -86,7 +86,7 @@ func init() {
 		},
 	})
 	RootCmd.PersistentFlags().BoolVarP(&useLedgerWallet, "ledger", "e", false, "Use ledger hardware wallet")
-	RootCmd.PersistentFlags().StringVar(&filepath, "file", "", "Absolute path to file containing arguments")
+	RootCmd.PersistentFlags().StringVar(&givenFilePath, "file", "", "Absolute path to file containing arguments")
 	RootCmd.AddCommand(&cobra.Command{
 		Use:   "docs",
 		Short: fmt.Sprintf("Generate docs to a local %s directory", hmyDocsDir),

--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -86,7 +86,7 @@ func init() {
 		},
 	})
 	RootCmd.PersistentFlags().BoolVarP(&useLedgerWallet, "ledger", "e", false, "Use ledger hardware wallet")
-	RootCmd.PersistentFlags().StringVar(&givenFilePath, "file", "", "Absolute path to file containing arguments")
+	RootCmd.PersistentFlags().StringVar(&givenFilePath, "file", "", "Path to file for given command when applicable")
 	RootCmd.AddCommand(&cobra.Command{
 		Use:   "docs",
 		Short: fmt.Sprintf("Generate docs to a local %s directory", hmyDocsDir),

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -114,7 +114,7 @@ func handleStakingTransaction(
 			return errors.New("error : delegator address doesn't match with ledger hardware addresss")
 		}
 	} else {
-		ks, acct, err = store.UnlockedKeystore(from, unlockP)
+		ks, acct, err = store.UnlockedKeystore(from, passphrase)
 		if err != nil {
 			return err
 		}
@@ -340,6 +340,11 @@ Create a new validator"
 				return err
 			}
 
+			passphrase, err = getPassphrase()
+			if err != nil {
+				return err
+			}
+
 			err = handleStakingTransaction(stakingTx, networkHandler, validatorAddress)
 			if err != nil {
 				return err
@@ -368,10 +373,8 @@ Create a new validator"
 	subCmdNewValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdNewValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdNewValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	subCmdNewValidator.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock delegator's keystore",
-	)
+	subCmdNewValidator.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	subCmdNewValidator.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	for _, flagName := range [...]string{"name", "identity", "website", "security-contact", "details", "rate", "max-rate",
 		"max-change-rate", "min-self-delegation", "max-total-delegation", "validator-addr", "bls-pubkeys", "amount"} {
@@ -468,6 +471,11 @@ Create a new validator"
 				return err
 			}
 
+			passphrase, err = getPassphrase()
+			if err != nil {
+				return err
+			}
+
 			err = handleStakingTransaction(stakingTx, networkHandler, validatorAddress)
 			if err != nil {
 				return err
@@ -493,10 +501,8 @@ Create a new validator"
 	subCmdEditValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdEditValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdEditValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	subCmdEditValidator.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock delegator's keystore",
-	)
+	subCmdEditValidator.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	subCmdEditValidator.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	for _, flagName := range [...]string{
 		"name", "identity", "website", "security-contact", "details", "rate",
@@ -537,6 +543,11 @@ Delegating to a validator
 				return err
 			}
 
+			passphrase, err = getPassphrase()
+			if err != nil {
+				return err
+			}
+
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
 				return err
@@ -553,10 +564,8 @@ Delegating to a validator
 	subCmdDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	subCmdDelegate.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock delegator's keystore",
-	)
+	subCmdDelegate.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	subCmdDelegate.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	for _, flagName := range [...]string{"delegator-addr", "validator-addr", "amount"} {
 		subCmdDelegate.MarkFlagRequired(flagName)
@@ -594,6 +603,11 @@ Delegating to a validator
 				return err
 			}
 
+			passphrase, err = getPassphrase()
+			if err != nil {
+				return err
+			}
+
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
 				return err
@@ -610,10 +624,8 @@ Delegating to a validator
 	subCmdUnDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdUnDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdUnDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	subCmdUnDelegate.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock delegator's keystore",
-	)
+	subCmdUnDelegate.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	subCmdUnDelegate.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	for _, flagName := range [...]string{"delegator-addr", "validator-addr", "amount"} {
 		subCmdUnDelegate.MarkFlagRequired(flagName)
@@ -646,6 +658,11 @@ Collect token rewards
 				return err
 			}
 
+			passphrase, err = getPassphrase()
+			if err != nil {
+				return err
+			}
+
 			err = handleStakingTransaction(stakingTx, networkHandler, delegatorAddress)
 			if err != nil {
 				return err
@@ -660,10 +677,8 @@ Collect token rewards
 	subCmdCollectRewards.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for tx")
 	subCmdCollectRewards.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	subCmdCollectRewards.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	subCmdCollectRewards.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock delegator's keystore",
-	)
+	subCmdCollectRewards.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	subCmdCollectRewards.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	for _, flagName := range [...]string{"delegator-addr"} {
 		subCmdCollectRewards.MarkFlagRequired(flagName)

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -29,7 +29,6 @@ var (
 	confirmWait uint32
 	chainName   = chainIDWrapper{chainID: &common.Chain.TestNet}
 	dryRun      bool
-	unlockP     string
 	inputNonce  string
 	gasPrice    string
 	gasLimit    uint64
@@ -286,10 +285,8 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 	cmdTransfer.Flags().Uint32Var(&toShardID, "to-shard", 0, "target shard id")
 	cmdTransfer.Flags().Var(&chainName, "chain-id", "what chain ID to target")
 	cmdTransfer.Flags().Uint32Var(&confirmWait, "wait-for-confirm", 0, "only waits if non-zero value, in seconds")
-	cmdTransfer.Flags().StringVar(&unlockP,
-		"passphrase", common.DefaultPassphrase,
-		"passphrase to unlock sender's keystore",
-	)
+	cmdTransfer.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
+	cmdTransfer.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
 	RootCmd.AddCommand(cmdTransfer)
 }

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -19,7 +19,11 @@ Cookbook of Usage
 Note:
 
 1) Every subcommand recognizes a '--help' flag
-2) These examples use shard 1 of testnet as argument for --node
+2) If a passphrase is used by a subcommand, one can enter their own passphrase interactively
+   with the --passphrase option. Alternatively, one can pass their own passphrase via a file
+   using the --passphrase-file option. If no passphrase option is selected, the default 
+   passphrase of '' is used.   
+3) These examples use shard 1 of testnet as argument for --node
 
 Examples:
 
@@ -39,19 +43,44 @@ hmy --node="https://api.s1.p.hmny.io/" transfer \
     --from-shard 0 --to-shard 1 --amount 200
 
 %s
+hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
+    
+    Example of JSON file format:
+      [
+        {
+          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+          "from-shard" : "0",
+          "to-shard": "0",
+          "amount": "1",
+          "passphrase-string": "",
+          "nonce": "-1",
+          "stop-on-error": true
+        },
+        {
+          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
+          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
+          "from-shard" : "0",
+          "to-shard": "0",
+          "amount": "1",
+          "passphrase-file": "./pw.txt"
+        }
+      ]
+
+%s
 hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
 %s
 hmy keys add --recover
 
 %s
-hmy keys import-ks <SOME_ABSOLUTE_PATH_TO_KEYSTORE_JSON>.key
+hmy keys import-ks <PATH_TO_KEYSTORE_JSON>.key
 
 %s
 hmy keys import-private-key <secp256k1_PRIVATE_KEY>
 
 %s
-hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase <YOUR_PASSWORD>
+hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
 
 %s
 hmy keys generate-bls-key --bls-file-path /tmp/file.key
@@ -60,28 +89,28 @@ hmy keys generate-bls-key --bls-file-path /tmp/file.key
 hmy --node="https://api.s1.p.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
-    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase <YOUR_PASSWORD>
+    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase 
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
-    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase <YOUR_PASSWORD>
+    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase 
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase <YOUR_PASSWORD>
+    --amount 10 --passphrase 
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase <YOUR_PASSWORD>
+    --amount 10 --passphrase 
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking collect-rewards \
-    --delegator-addr <SOME_ONE_ADDRESS> --passphrase <YOUR_PASSWORD>
+    --delegator-addr <SOME_ONE_ADDRESS> --passphrase 
 
 %s
 hmy --node="https://api.s1.p.hmny.io" blockchain validator all-active
@@ -93,19 +122,20 @@ hmy failures staking
 		g("1.  Check account balance on given chain"),
 		g("2.  Check sent transaction"),
 		g("3.  List local account keys"),
-		g("4.  Sending a transaction (add --wait-for-confirm=10 to wait 10 seconds for confirmation)"),
-		g("5.  Check a completed transaction receipt"),
-		g("6.  Import an account using the mnemonic. Prompts the user to give the mnemonic."),
-		g("7.  Import an existing keystore file"),
-		g("8.  Import a keystore file using a secp256k1 private key"),
-		g("9.  Export a keystore file's secp256k1 private key"),
-		g("10. Generate a BLS key then encrypt and save the private key to the specified location. Prompts user to give a password to lock the file."),
-		g("11. Create a new validator with a list of BLS keys"),
-		g("12. Edit an existing validator"),
-		g("13. Delegate an amount to a validator"),
-		g("14. Undelegate to a validator"),
-		g("15. Collect block rewards as a delegator"),
-		g("16. Check active validators"),
-		g("17. Check in-memory record of failed staking transactions"),
+		g("4.  Sending a transaction (add `--wait-for-confirm=10` to wait 10 seconds for confirmation)"),
+		g("5.  Sending a batch of transactions as dictated from a file (the `--wait-for-confirm` and `--dry-run` options still apply)"),
+		g("6.  Check a completed transaction receipt"),
+		g("7.  Import an account using the mnemonic. Prompts the user to give the mnemonic."),
+		g("8.  Import an existing keystore file"),
+		g("9.  Import a keystore file using a secp256k1 private key"),
+		g("10.  Export a keystore file's secp256k1 private key"),
+		g("11. Generate a BLS key then encrypt and save the private key to the specified location."),
+		g("12. Create a new validator with a list of BLS keys"),
+		g("13. Edit an existing validator"),
+		g("14. Delegate an amount to a validator"),
+		g("15. Undelegate to a validator"),
+		g("16. Collect block rewards as a delegator"),
+		g("17. Check active validators"),
+		g("18. Check in-memory record of failed staking transactions"),
 	)
 )

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -54,7 +54,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
           "to-shard": "0",
           "amount": "1",
           "passphrase-string": "",
-          "nonce": "-1",
+          "nonce": "1",
           "stop-on-error": true
         },
         {

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -90,7 +90,7 @@ func DefaultLocation() string {
 	return path.Join(uDir, c.DefaultConfigDirName, c.DefaultConfigAccountAliasesDirName)
 }
 
-func UnlockedKeystore(from, unlockP string) (*keystore.KeyStore, *accounts.Account, error) {
+func UnlockedKeystore(from, passphrase string) (*keystore.KeyStore, *accounts.Account, error) {
 	sender := address.Parse(from)
 	ks := FromAddress(from)
 	if ks == nil {
@@ -100,7 +100,7 @@ func UnlockedKeystore(from, unlockP string) (*keystore.KeyStore, *accounts.Accou
 	if lookupErr != nil {
 		return nil, nil, fmt.Errorf("could not find %s in keystore", from)
 	}
-	if unlockError := ks.Unlock(account, unlockP); unlockError != nil {
+	if unlockError := ks.Unlock(account, passphrase); unlockError != nil {
 		return nil, nil, errors.Wrap(NoUnlockBadPassphrase, unlockError.Error())
 	}
 	return ks, &account, nil

--- a/pkg/transaction/controller.go
+++ b/pkg/transaction/controller.go
@@ -238,7 +238,7 @@ func (C *Controller) hardwareSignAndPrepareTxEncodedForSending() {
 }
 
 func (C *Controller) txConfirmation() {
-	if C.failure != nil {
+	if C.failure != nil || C.Behavior.DryRun {
 		return
 	}
 	if C.Behavior.ConfirmationWaitTime > 0 {


### PR DESCRIPTION
## Key features:
* All passphrase related commands have 3 options. 1) use default passphrase (unchanged). 2) use passphrase from a file via the `passphrase-file` option. 3) provide passphrase interactively when the `passphrase` option it toggled. 
* Batched transactions now logs/returns relevant information from `transaction.Controller` instead of explicit fields. Note that single transaction JSON keys have not been changed for regular transactions. However, `dry-run` transactions now have the raw transaction in one JSON object. 

Batched transaction documentation added to README for reference:

# Sending batched transactions

One may find it useful to send a batch of transaction with 1 instance of the binary.
To do this, one can specify a JSON file with the `transaction` subcommand to dictate a batch of transaction to send off **in sequential order**. 

Example:
```
hmy --node="https://api.s1.p.hmny.io/" transfer --file ./batchTransactions.json
``` 

> Note that the `--wait-for-confirm` and `--dry-run` options still apply when sending batched transactions

## Transfer JSON file format
The JSON file will be a JSON array where each element has the following attributes:

| Key                 | Value-type | Value-description|
| :------------------:|:----------:| :----------------|
| `from`              | string     | [**Required**] Sender's one address, must have key in keystore. |
| `to`                | string     | [**Required**] The receivers one address. |
| `amount`            | string     | [**Required**] The amount to send in $ONE. |
| `from-shard`        | string     | [**Required**] The source shard. |
| `to-shard`          | string     | [**Required**] The destination shard. |
| `passphrase-file`   | string     | [*Optional*] The file path to file containing the passphrase in plain text. If none is provided, check for passphrase string. |
| `passphrase-string` | string     | [*Optional*] The passphrase as a string in plain text. If none is provided, passphrase is ''. |
| `nonce`             | string     | [*Optional*] The nonce of a specific transaction, default uses nonce from blockchain. |
| `gas-price`         | string     | [*Optional*] The gas price to pay in NANO (1e-9 of $ONE), default is 1. |
| `gas-limit`         | string     | [*Optional*] The gas limit, default is 21000. |
| `stop-on-error`     | boolean    | [*Optional*] If true, stop sending transactions if an error occurred, default is false. |

Example of JSON file:

```json
[
  {
    "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
    "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
    "from-shard" : "0",
    "to-shard": "0",
    "amount": "1",
    "passphrase-string": "",
    "nonce": "35",
    "stop-on-error": true
  },
  {
    "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
    "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
    "from-shard" : "0",
    "to-shard": "0",
    "amount": "1",
    "passphrase-file": "./pw.txt",
    "gas-price": "1",
    "gas-limit": "21000"
  }
]
```

## Batched transaction response format

The return will be a JSON array where each element is a transaction log.
The transaction log has the following attributes:

| Key                   | Value-type  | Value-description|
| :--------------------:|:-----------:| :----------------|
| `transaction-receipt` | string      | The transaction hash/receipt if the CLI signed **and sent** a transaction, otherwise this key will not exist |
| `transaction`         | JSON Object | The transaction parameters if `--dry-run` is toggled, otherwise this key will not exist. |
| `blockchain-receipt`  | JSON Object | The transaction receipt from the blockchain if `wait-for-confirm` is > 0, otherwise this key will not exist. |
| `raw-transaction`     | string      | The raw bytes in hex of a sighed transaction if `--dry-run` is toggled, otherwise this key will not exist |
| `errors`              | JSON Array  | A JSON array of strings describing **any** error that occurred during the execution of a transaction. If no errors, this key will not exist. |
| `time-signed-utc`     | string      | The time in UTC as a string of roughly when the transaction was signed. If no signed transaction, this key will not exist. |

Example of returned JSON Array:
```json
[
  {
    "errors": [
      "[2020-01-22 22:01:10.819406] strconv.ParseUint: parsing \"-1\": invalid syntax"
    ]
  },
  {
    "transaction-receipt": "0xf1706080ea9ac210ee2c12c69fb310be5a5da99582b7c783e2f741a3536abbfd",
    "blockchain-receipt": {
      "blockHash": "0xe6de09f4e0ca351257d301a50b4e2ca82646473dc1c4302b570bfab17d421850",
      "blockNumber": "0xb71",
      "contractAddress": null,
      "cumulativeGasUsed": "0x5208",
      "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
      "gasUsed": "0x5208",
      "logs": [],
      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
      "shardID": 0,
      "status": "0x1",
      "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
      "transactionHash": "0xf1706080ea9ac210ee2c12c69fb310be5a5da99582b7c783e2f741a3536abbfd",
      "transactionIndex": "0x0"
    },
    "time-signed-utc": "2020-01-22 22:01:11.468407"
  }
]
```