### PR TITLE
Adding support to avoid having the same keystore file added twice

### DIFF
--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -7,15 +7,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"os"
 	"github.com/harmony-one/go-sdk/pkg/address"
 	"github.com/harmony-one/harmony/accounts/keystore"
+	c "github.com/harmony-one/go-sdk/pkg/common"
+	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/btcsuite/btcd/btcec"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/harmony-one/go-sdk/pkg/common"
 	"github.com/harmony-one/go-sdk/pkg/mnemonic"
 	"github.com/harmony-one/go-sdk/pkg/store"
-	"github.com/pkg/errors"
 )
 
 // ImportFromPrivateKey allows import of an ECDSA private key
@@ -99,10 +101,15 @@ func ImportKeyStore(keyPath, name, passphrase string) (string, error) {
 	if hasAddress {
 		return "", fmt.Errorf("address %s already exists in keystore", b32)
 	}
-	ks := store.FromAccountName(name)
-	_, err = ks.Import(keyJSON, passphrase, passphrase)
+	uDir, _ := homedir.Dir()
+	path := filepath.Join(uDir, c.DefaultConfigDirName, c.DefaultConfigAccountAliasesDirName, name)	
+	err = os.MkdirAll(path, 0600)
 	if err != nil {
-		return "", errors.Wrap(err, "could not import")
+		return "", err
+	}
+	err = ioutil.WriteFile(filepath.Join(path, filepath.Base(keyPath)), keyJSON, 0600)
+	if err != nil {
+		return "", err
 	}
 	return name, nil
 }

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -57,24 +57,6 @@ func DescribeLocalAccounts() {
 	}
 }
 
-// check if the given address is already imported in present twice
-func DoesAddressExistTwice(oneaddress string) bool {
-	count := 0
-	for _, name := range LocalAccounts() {
-		ks := FromAccountName(name)
-		allAccounts := ks.Accounts()
-		for _, account := range allAccounts {
-			if oneaddress == address.ToBech32(account.Address) {
-				count++
-			}
-			if count == 2 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func DoesNamedAccountExist(name string) bool {
 	for _, account := range LocalAccounts() {
 		if account == name {

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -46,6 +46,7 @@ var (
 	NoUnlockBadPassphrase = errors.New("could not unlock account with passphrase, perhaps need different phrase")
 )
 
+// DescribeLocalAccounts will display all the account alias name and their corresponding one address
 func DescribeLocalAccounts() {
 	fmt.Println(describe)
 	for _, name := range LocalAccounts() {
@@ -57,6 +58,8 @@ func DescribeLocalAccounts() {
 	}
 }
 
+// DoesNamedAccountExist return true if the given string name is an alias account already define, 
+// and return false otherwise
 func DoesNamedAccountExist(name string) bool {
 	for _, account := range LocalAccounts() {
 		if account == name {
@@ -66,6 +69,7 @@ func DoesNamedAccountExist(name string) bool {
 	return false
 }
 
+// FromAddress will return nil if the bech32 string is not found in the imported accounts
 func FromAddress(bech32 string) *keystore.KeyStore {
 	for _, name := range LocalAccounts() {
 		ks := FromAccountName(name)
@@ -78,6 +82,7 @@ func FromAddress(bech32 string) *keystore.KeyStore {
 	}
 	return nil
 }
+
 
 func FromAccountName(name string) *keystore.KeyStore {
 	uDir, _ := homedir.Dir()

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -57,6 +57,24 @@ func DescribeLocalAccounts() {
 	}
 }
 
+// check if the given address is already imported in the local keystore
+func DoesAddressExistTwice(oneaddress string) bool {
+	count := 0
+	for _, name := range LocalAccounts() {
+		ks := FromAccountName(name)
+		allAccounts := ks.Accounts()
+		for _, account := range allAccounts {
+			if oneaddress == address.ToBech32(account.Address) {
+				count++
+			}
+			if count == 2 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func DoesNamedAccountExist(name string) bool {
 	for _, account := range LocalAccounts() {
 		if account == name {

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -57,7 +57,7 @@ func DescribeLocalAccounts() {
 	}
 }
 
-// check if the given address is already imported in the local keystore
+// check if the given address is already imported in present twice
 func DoesAddressExistTwice(oneaddress string) bool {
 	count := 0
 	for _, name := range LocalAccounts() {


### PR DESCRIPTION
I didn't found a very good way to obtain the ONE address without importing it first. Hence the need to create that new method DoesAddressExistTwice and remove the account from the keystore if the ONE address is found twice.

Please suggest if there is a better way to do this.
```
root@48e98e352df0:~/go/src/github.com/harmony-one/go-sdk# dist/hmy keys list
NAME                                                    ADDRESS

root@48e98e352df0:~/go/src/github.com/harmony-one/go-sdk# dist/hmy keys import-ks $(pwd)/UTC--2020-01-25T20-50-41.577244708Z--8ceda0fd494b2848fbb64b083409a7c1dcce3bfb
Imported keystore given account alias of `thunder-imported`
root@48e98e352df0:~/go/src/github.com/harmony-one/go-sdk# dist/hmy keys list
NAME                                                    ADDRESS

thunder-imported                                        one13nk6pl2ffv5y37akfvyrgzd8c8wvuwlm0g9l7l
root@48e98e352df0:~/go/src/github.com/harmony-one/go-sdk# dist/hmy keys import-ks $(pwd)/UTC--2020-01-25T20-50-41.577244708Z--8ceda0fd494b2848fbb64b083409a7c1dcce3bfb
commit: v238-878cc03-dirty, error: account one13nk6pl2ffv5y37akfvyrgzd8c8wvuwlm0g9l7l already exists
check hmy cookbook for valid examples or try adding a `--help` flag
root@48e98e352df0:~/go/src/github.com/harmony-one/go-sdk#
```