### PR TITLE
[#2197] Fix blockchain validator metrics command

### DIFF
--- a/cmd/subcommands/validator.go
+++ b/cmd/subcommands/validator.go
@@ -25,7 +25,8 @@ var (
 		Args:    cobra.ExactArgs(1),
 		PreRunE: validateAddress,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return request(rpc.Method.GetValidatorMetrics, []interface{}{})
+			noLatest = true
+			return request(rpc.Method.GetValidatorMetrics, []interface{}{args[0]})
 		},
 	}, {
 		Use:     "information",


### PR DESCRIPTION
```
$ hmyStaking blockchain validator metrics one1gjsxmewzws9mt3fn65jmdhr3e4hel9xza8wd6t
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "blocks-jailed": 0,
    "bls-keys-per-shard": [
      {
        "bls-public-keys": [
          "a689b39bb1de4f1591e29094b91d00596b0f371ea16fadf8b4143c680a1f9aff3e805e167eda2c583827ed0e7c8c9882"
        ],
        "shard-id": 0
      }
    ],
    "total-effective-stake": "11500000000000000000.000000000000000000",
    "voting-power-per-shard": [
      {
        "shard-id": 0,
        "voting-power": "0.023365079365079365"
      }
    ]
  }
}
```
```
$ hmyStaking blockchain validator metrics one1txy0a2szxlk7z0dvvfgv24kjjv60w2mcnyfl8a
commit: v265-7782446-dirty, error: Catch all RPC error: validator stats not found: 0x5988fEaa0237EDe13DaC6250C556d29334F72B78
check hmy cookbook for valid examples or try adding a `--help` flag
```