### PR TITLE
[#2197] Add clarification for errors message on blockchain validators metrics

### DIFF
--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -40,10 +40,10 @@ var (
 		}
 		asJSON, _ := json.Marshal(success)
 		if noPrettyOutput {
-			fmt.Print(string(asJSON))
+			fmt.Println(string(asJSON))
 			return nil
 		}
-		fmt.Print(common.JSONPrettyFormat(string(asJSON)))
+		fmt.Println(common.JSONPrettyFormat(string(asJSON)))
 		return nil
 	}
 	// RootCmd is single entry point of the CLI

--- a/cmd/subcommands/validator.go
+++ b/cmd/subcommands/validator.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/harmony-one/go-sdk/pkg/rpc"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +28,11 @@ var (
 		PreRunE: validateAddress,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			noLatest = true
-			return request(rpc.Method.GetValidatorMetrics, []interface{}{args[0]})
+			e := request(rpc.Method.GetValidatorMetrics, []interface{}{args[0]})
+			if e != nil {
+				fmt.Println("Metrics are only available for Validators that have participated in consensus committee.")
+			}
+			return e
 		},
 	}, {
 		Use:     "information",


### PR DESCRIPTION
```
$ hmyStaking blockchain validator metrics one1txy0a2szxlk7z0dvvfgv24kjjv60w2mcnyfl8a
Metrics are only available for Validators that have participated in consensus committee.
commit: v266-558cc6b-dirty, error: Catch all RPC error: validator stats not found: 0x5988fEaa0237EDe13DaC6250C556d29334F72B78
check hmy cookbook for valid examples or try adding a `--help` flag
```