### PR TITLE
Add txn error fetch from error sink to SDK and plain txn Controller

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -155,8 +155,8 @@ func handleStakingTransaction(
 		return err
 	}
 	r, _ := reply["result"].(string)
-	if confirmWait > 0 {
-		confirmTx(networkHandler, confirmWait, r)
+	if timeout > 0 {
+		confirmTx(networkHandler, timeout, r)
 	} else {
 		fmt.Println(fmt.Sprintf(`{"transaction-receipt":"%s"}`, r))
 	}
@@ -414,7 +414,7 @@ Create a new validator"
 	subCmdNewValidator.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
 	subCmdNewValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdNewValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
-	subCmdNewValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", waitTime, "only waits if non-zero value, in seconds")
+	subCmdNewValidator.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for tx confirm")
 	subCmdNewValidator.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	subCmdNewValidator.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
@@ -576,7 +576,7 @@ Create a new validator"
 	subCmdEditValidator.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
 	subCmdEditValidator.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdEditValidator.Flags().Var(&chainName, "chain-id", "what chain ID to target")
-	subCmdEditValidator.Flags().Uint32Var(&confirmWait, "wait-for-confirm", waitTime, "only waits if non-zero value, in seconds")
+	subCmdEditValidator.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for tx confirm")
 	subCmdEditValidator.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	subCmdEditValidator.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
@@ -633,7 +633,7 @@ Delegating to a validator
 	subCmdDelegate.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
 	subCmdDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
-	subCmdDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", waitTime, "only waits if non-zero value, in seconds")
+	subCmdDelegate.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for tx confirm")
 	subCmdDelegate.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	subCmdDelegate.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
@@ -693,7 +693,7 @@ Delegating to a validator
 	subCmdUnDelegate.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
 	subCmdUnDelegate.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for transaction")
 	subCmdUnDelegate.Flags().Var(&chainName, "chain-id", "what chain ID to target")
-	subCmdUnDelegate.Flags().Uint32Var(&confirmWait, "wait-for-confirm", waitTime, "only waits if non-zero value, in seconds")
+	subCmdUnDelegate.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for tx confirm")
 	subCmdUnDelegate.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	subCmdUnDelegate.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 
@@ -746,7 +746,7 @@ Collect token rewards
 	subCmdCollectRewards.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
 	subCmdCollectRewards.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for tx")
 	subCmdCollectRewards.Flags().Var(&chainName, "chain-id", "what chain ID to target")
-	subCmdCollectRewards.Flags().Uint32Var(&confirmWait, "wait-for-confirm", waitTime, "only waits if non-zero value, in seconds")
+	subCmdCollectRewards.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for tx confirm")
 	subCmdCollectRewards.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
 	subCmdCollectRewards.Flags().StringVar(&passphraseFilePath, "passphrase-file", "", "path to a file containing the passphrase")
 

--- a/pkg/transaction/controller.go
+++ b/pkg/transaction/controller.go
@@ -22,6 +22,10 @@ import (
 var (
 	nanoAsDec = numeric.NewDec(denominations.Nano)
 	oneAsDec  = numeric.NewDec(denominations.One)
+
+	// ErrBadTransactionParam is returned when invalid params are given to the
+	// controller upon execution of a transaction.
+	ErrBadTransactionParam = errors.New("transaction has bad parameters")
 )
 
 type p []interface{}
@@ -30,9 +34,9 @@ type transactionForRPC struct {
 	params      map[string]interface{}
 	transaction *Transaction
 	// Hex encoded
-	signature   *string
-	receiptHash *string
-	receipt     rpc.Reply
+	signature       *string
+	transactionHash *string
+	receipt         rpc.Reply
 }
 
 type sender struct {
@@ -42,7 +46,8 @@ type sender struct {
 
 // Controller drives the transaction signing process
 type Controller struct {
-	failure           error
+	executionError    error
+	transactionErrors Errors
 	messenger         rpc.T
 	sender            sender
 	transactionForRPC transactionForRPC
@@ -58,25 +63,23 @@ type behavior struct {
 
 // NewController initializes a Controller, caller can control behavior via options
 func NewController(
-	handler rpc.T,
-	senderKs *keystore.KeyStore,
-	senderAcct *accounts.Account,
-	chain common.ChainID,
-	options ...func(*Controller)) *Controller {
-
+	handler rpc.T, senderKs *keystore.KeyStore,
+	senderAcct *accounts.Account, chain common.ChainID,
+	options ...func(*Controller),
+) *Controller {
 	txParams := make(map[string]interface{})
 	ctrlr := &Controller{
-		failure:   nil,
-		messenger: handler,
+		executionError: nil,
+		messenger:      handler,
 		sender: sender{
 			ks:      senderKs,
 			account: senderAcct,
 		},
 		transactionForRPC: transactionForRPC{
-			params:      txParams,
-			signature:   nil,
-			receiptHash: nil,
-			receipt:     nil,
+			params:          txParams,
+			signature:       nil,
+			transactionHash: nil,
+			receipt:         nil,
 		},
 		chain:    chain,
 		Behavior: behavior{false, Software, 0},
@@ -87,89 +90,7 @@ func NewController(
 	return ctrlr
 }
 
-func (C *Controller) verifyBalance() {
-	if C.failure != nil {
-		return
-	}
-	balanceRPCReply, err := C.messenger.SendRPC(
-		rpc.Method.GetBalance,
-		p{address.ToBech32(C.sender.account.Address), "latest"},
-	)
-	if err != nil {
-		C.failure = err
-		return
-	}
-	currentBalance, _ := balanceRPCReply["result"].(string)
-	bal, _ := new(big.Int).SetString(currentBalance[2:], 16)
-	balance := numeric.NewDecFromBigInt(bal)
-	gasAsDec := C.transactionForRPC.params["gas-price"].(numeric.Dec)
-	gasAsDec = gasAsDec.Mul(numeric.NewDec(int64(C.transactionForRPC.params["gas-limit"].(uint64))))
-	total := C.transactionForRPC.params["transfer-amount"].(numeric.Dec).Add(gasAsDec)
-
-	if total.GT(balance) {
-		b := balance.Quo(oneAsDec)
-		t := total.Quo(oneAsDec)
-		C.failure = fmt.Errorf(
-			"insufficient balance of %s in shard %d for the requested transfer of %s", b.String(), C.transactionForRPC.params["from-shard"].(uint32), t.String(),
-		)
-	}
-}
-
-func (C *Controller) sendSignedTx() {
-	if C.failure != nil || C.Behavior.DryRun {
-		return
-	}
-	reply, err := C.messenger.SendRPC(rpc.Method.SendRawTransaction, p{C.transactionForRPC.signature})
-	if err != nil {
-		C.failure = err
-		return
-	}
-	r, _ := reply["result"].(string)
-	C.transactionForRPC.receiptHash = &r
-}
-
-func (C *Controller) setIntrinsicGas(gasLimit uint64) {
-	if C.failure != nil {
-		return
-	}
-	C.transactionForRPC.params["gas-limit"] = gasLimit
-}
-
-func (C *Controller) setGasPrice(gasPrice numeric.Dec) {
-	if C.failure != nil {
-		return
-	}
-	C.transactionForRPC.params["gas-price"] = gasPrice.Mul(nanoAsDec)
-}
-
-func (C *Controller) setAmount(amount numeric.Dec) {
-	amt := amount.Mul(oneAsDec)
-	C.transactionForRPC.params["transfer-amount"] = amt
-}
-
-func (C *Controller) setReceiver(receiver string) {
-	C.transactionForRPC.params["receiver"] = address.Parse(receiver)
-}
-
-func (C *Controller) setNewTransactionWithDataAndGas(i string) {
-	if C.failure != nil {
-		return
-	}
-
-	tx := NewTransaction(
-		C.transactionForRPC.params["nonce"].(uint64),
-		C.transactionForRPC.params["gas-limit"].(uint64),
-		C.transactionForRPC.params["receiver"].(address.T),
-		C.transactionForRPC.params["from-shard"].(uint32),
-		C.transactionForRPC.params["to-shard"].(uint32),
-		C.transactionForRPC.params["transfer-amount"].(numeric.Dec),
-		C.transactionForRPC.params["gas-price"].(numeric.Dec),
-		[]byte(i),
-	)
-	C.transactionForRPC.transaction = tx
-}
-
-// TransactionToJSON dumps JSON rep
+// TransactionToJSON dumps JSON representation
 func (C *Controller) TransactionToJSON(pretty bool) string {
 	r, _ := C.transactionForRPC.transaction.MarshalJSON()
 	if pretty {
@@ -183,14 +104,103 @@ func (C *Controller) RawTransaction() string {
 	return *C.transactionForRPC.signature
 }
 
+func (C *Controller) TransactionHash() *string {
+	return C.transactionForRPC.transactionHash
+}
+
+func (C *Controller) Receipt() rpc.Reply {
+	return C.transactionForRPC.receipt
+}
+
+func (C *Controller) TransactionErrors() Errors {
+	return C.transactionErrors
+}
+
+func (C *Controller) setShardIDs(fromShard, toShard int) {
+	if C.executionError != nil {
+		return
+	}
+	C.transactionForRPC.params["from-shard"] = uint32(fromShard)
+	C.transactionForRPC.params["to-shard"] = uint32(toShard)
+}
+
+func (C *Controller) setIntrinsicGas(gasLimit uint64) {
+	if C.executionError != nil {
+		return
+	}
+	C.transactionForRPC.params["gas-limit"] = gasLimit
+}
+
+func (C *Controller) setGasPrice(gasPrice numeric.Dec) {
+	if C.executionError != nil {
+		return
+	}
+	C.transactionForRPC.params["gas-price"] = gasPrice.Mul(nanoAsDec)
+}
+
+func (C *Controller) setAmount(amount numeric.Dec) {
+	if C.executionError != nil {
+		return
+	}
+	balanceRPCReply, err := C.messenger.SendRPC(
+		rpc.Method.GetBalance,
+		p{address.ToBech32(C.sender.account.Address), "latest"},
+	)
+	if err != nil {
+		C.executionError = err
+		return
+	}
+	currentBalance, _ := balanceRPCReply["result"].(string)
+	bal, _ := new(big.Int).SetString(currentBalance[2:], 16)
+	balance := numeric.NewDecFromBigInt(bal)
+	gasAsDec := C.transactionForRPC.params["gas-price"].(numeric.Dec)
+	gasAsDec = gasAsDec.Mul(numeric.NewDec(int64(C.transactionForRPC.params["gas-limit"].(uint64))))
+	amountInAtto := amount.Mul(oneAsDec)
+	total := amountInAtto.Add(gasAsDec)
+
+	if total.GT(balance) {
+		balanceInOne := balance.Quo(oneAsDec)
+		C.executionError = ErrBadTransactionParam
+		errorMsg := fmt.Sprintf(
+			"insufficient balance of %s in shard %d for the requested transfer of %s",
+			balanceInOne.String(), C.transactionForRPC.params["from-shard"].(uint32), amount.String(),
+		)
+		C.transactionErrors = append(C.transactionErrors, &Error{
+			ErrMessage:           &errorMsg,
+			TimestampOfRejection: time.Now().Unix(),
+		})
+	}
+	C.transactionForRPC.params["transfer-amount"] = amountInAtto
+}
+
+func (C *Controller) setReceiver(receiver string) {
+	C.transactionForRPC.params["receiver"] = address.Parse(receiver)
+}
+
+func (C *Controller) setNewTransactionWithDataAndGas(data []byte) {
+	if C.executionError != nil {
+		return
+	}
+	C.transactionForRPC.transaction = NewTransaction(
+		C.transactionForRPC.params["nonce"].(uint64),
+		C.transactionForRPC.params["gas-limit"].(uint64),
+		C.transactionForRPC.params["receiver"].(address.T),
+		C.transactionForRPC.params["from-shard"].(uint32),
+		C.transactionForRPC.params["to-shard"].(uint32),
+		C.transactionForRPC.params["transfer-amount"].(numeric.Dec),
+		C.transactionForRPC.params["gas-price"].(numeric.Dec),
+		data,
+	)
+}
+
 func (C *Controller) signAndPrepareTxEncodedForSending() {
-	if C.failure != nil {
+	if C.executionError != nil {
 		return
 	}
 	signedTransaction, err :=
 		C.sender.ks.SignTx(*C.sender.account, C.transactionForRPC.transaction, C.chain.Value)
 	if err != nil {
-		C.failure = err
+		C.executionError = err
 		return
 	}
 	C.transactionForRPC.transaction = signedTransaction
@@ -204,75 +214,85 @@ func (C *Controller) signAndPrepareTxEncodedForSending() {
 	}
 }
 
-func (C *Controller) setShardIDs(fromShard, toShard int) {
-	if C.failure != nil {
-		return
-	}
-	C.transactionForRPC.params["from-shard"] = uint32(fromShard)
-	C.transactionForRPC.params["to-shard"] = uint32(toShard)
-}
-
-func (C *Controller) ReceiptHash() *string {
-	return C.transactionForRPC.receiptHash
-}
-
-func (C *Controller) Receipt() rpc.Reply {
-	return C.transactionForRPC.receipt
-}
-
 func (C *Controller) hardwareSignAndPrepareTxEncodedForSending() {
-	if C.failure != nil {
+	if C.executionError != nil {
 		return
 	}
 	enc, signerAddr, err := ledger.SignTx(C.transactionForRPC.transaction, C.chain.Value)
 	if err != nil {
-		C.failure = err
+		C.executionError = err
 		return
 	}
 	if strings.Compare(signerAddr, address.ToBech32(C.sender.account.Address)) != 0 {
-		C.failure = errors.New("signature verification failed : sender address doesn't match with ledger hardware addresss")
+		C.executionError = ErrBadTransactionParam
+		errorMsg := "signature verification failed : sender address doesn't match with ledger hardware addresss"
+		C.transactionErrors = append(C.transactionErrors, &Error{
+			ErrMessage:           &errorMsg,
+			TimestampOfRejection: time.Now().Unix(),
+		})
 		return
 	}
 	hexSignature := hexutil.Encode(enc)
 	C.transactionForRPC.signature = &hexSignature
 }
 
+func (C *Controller) sendSignedTx() {
+	if C.executionError != nil || C.Behavior.DryRun {
+		return
+	}
+	reply, err := C.messenger.SendRPC(rpc.Method.SendRawTransaction, p{C.transactionForRPC.signature})
+	if err != nil {
+		C.executionError = err
+		return
+	}
+	r, _ := reply["result"].(string)
+	C.transactionForRPC.transactionHash = &r
+}
+
 func (C *Controller) txConfirmation() {
-	if C.failure != nil || C.Behavior.DryRun {
+	if C.executionError != nil || C.Behavior.DryRun {
 		return
 	}
 	if C.Behavior.ConfirmationWaitTime > 0 {
-		receipt := *C.ReceiptHash()
+		txHash := *C.TransactionHash()
 		start := int(C.Behavior.ConfirmationWaitTime)
 		for {
 			if start < 0 {
+				transactionErrors, err := GetError(txHash, C.messenger)
+				if err != nil {
+					C.executionError = err
+					return
+				}
+				C.transactionErrors = append(C.transactionErrors, transactionErrors...)
+				C.executionError = fmt.Errorf("could not confirm transaction after %d seconds", C.Behavior.ConfirmationWaitTime)
 				return
 			}
-			r, _ := C.messenger.SendRPC(rpc.Method.GetTransactionReceipt, p{receipt})
+			r, _ := C.messenger.SendRPC(rpc.Method.GetTransactionReceipt, p{txHash})
 			if r["result"] != nil {
 				C.transactionForRPC.receipt = r
 				return
 			}
-			time.Sleep(time.Second * 2)
-			start = start - 2
+			time.Sleep(time.Second)
+			start -= 1
 		}
 	}
 }
 
-// ExecuteTransaction is the single entrypoint to execute a transaction.
+// ExecuteTransaction is the single entrypoint to execute a plain transaction.
 // Each step in transaction creation, execution probably includes a mutation
-// Each becomes a no-op if failure occured in any previous step
+// Each becomes a no-op if executionError occurred in any previous step
 func (C *Controller) ExecuteTransaction(
-	to, inputData string,
-	amount, gasPrice numeric.Dec, nonce, gasLimit uint64,
-	fromShard, toShard int,
+	nonce, gasLimit uint64,
+	to string,
+	shardID, toShardID int,
+	amount, gasPrice numeric.Dec,
+	inputData []byte,
 ) error {
 	// WARNING Order of execution matters
-	C.setShardIDs(fromShard, toShard)
+	C.setShardIDs(shardID, toShardID)
 	C.setIntrinsicGas(gasLimit)
 	C.setGasPrice(gasPrice)
 	C.setAmount(amount)
-	C.verifyBalance()
 	C.setReceiver(to)
 	C.transactionForRPC.params["nonce"] = nonce
 	C.setNewTransactionWithDataAndGas(inputData)
@@ -284,5 +304,7 @@ func (C *Controller) ExecuteTransaction(
 	}
 	C.sendSignedTx()
 	C.txConfirmation()
-	return C.failure
+	return C.executionError
 }
+
+// TODO: add logic to create staking transactions in the SDK.

--- a/pkg/transaction/errors.go
+++ b/pkg/transaction/errors.go
@@ -1,0 +1,73 @@
+package transaction
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/harmony-one/go-sdk/pkg/rpc"
+)
+
+var (
+	errorSinkRPCs = []string{
+		rpc.Method.GetCurrentTransactionErrorSink,
+		rpc.Method.GetCurrentStakingErrorSink,
+	}
+)
+
+// Error is the struct for all errors in the error sinks.
+// Note that StakingDirective is non-nil for staking txn errors.
+type Error struct {
+	TxHashID             *string `json:"tx-hash-id"`
+	StakingDirective     *string `json:"directive-kind"` // optional error field for staking
+	ErrMessage           *string `json:"error-message"`
+	TimestampOfRejection int64   `json:"time-at-rejection"`
+}
+
+// Error an error with the ErrMessage and TimestampOfRejection as the message.
+func (e *Error) Error() error {
+	if e.StakingDirective != nil {
+		return fmt.Errorf("[%s] %s -- %s",
+			*e.StakingDirective, *e.ErrMessage, time.Unix(e.TimestampOfRejection, 0).String(),
+		)
+	} else {
+		return fmt.Errorf("[Plain transaction] %s -- %s",
+			*e.ErrMessage, time.Unix(e.TimestampOfRejection, 0).String(),
+		)
+	}
+}
+
+// Errors ...
+type Errors []*Error
+
+func getTxErrorBySink(txHash, errorSinkRPC string, messenger rpc.T) (Errors, error) {
+	var txErrors Errors
+	response, err := messenger.SendRPC(errorSinkRPC, []interface{}{})
+	if err != nil {
+		return nil, err
+	}
+	var allErrors []Error
+	asJSON, _ := json.Marshal(response["result"])
+	_ = json.Unmarshal(asJSON, &allErrors)
+	for i := range allErrors {
+		txError := allErrors[i]
+		if *txError.TxHashID == txHash {
+			txErrors = append(txErrors, &txError)
+		}
+	}
+	return txErrors, nil
+}
+
+// GetError returns all errors for a given (staking or plain) transaction hash.
+func GetError(txHash string, messenger rpc.T) (Errors, error) {
+	for _, errorSinkRpc := range errorSinkRPCs {
+		txErrors, err := getTxErrorBySink(txHash, errorSinkRpc, messenger)
+		if err != nil {
+			return Errors{}, err
+		}
+		if txErrors != nil {
+			return txErrors, nil
+		}
+	}
+	return Errors{}, nil
+}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -17,8 +17,7 @@ func NewTransaction(
 	shardID, toShardID uint32,
 	amount, gasPrice numeric.Dec,
 	data []byte) *Transaction {
-	// types.New
-	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount.TruncateInt(), gasLimit, gasPrice.TruncateInt(), data)
+	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount.TruncateInt(), gasLimit, gasPrice.TruncateInt(), data[:])
 }
 
 func GetNextNonce(addr string, messenger rpc.T) uint64 {


### PR DESCRIPTION
Currently, in the CLI, regular transactions don't report errors from the error sink in the errors JSON array if they timeout. This PR implements this. In the processes I did the following:
* Add functionality to get Errors by Hash in the SDK (works for both staking and regular txs)
* Refactor the transaction controller to fetch tx errors on timeout and expose a method to access the errors. 
* Refactor the transaction controller to take data as a byte slice instead of a string
* Change the `wait-for-confirm` to `timeout` but always enable wait for confirming. One can set timeout to 0 to just send the tx with waiting for it to finalize.
* Change 'transaction-receipt' to 'transaction-hash' for clarity.

A successful transaction (with timeout 40 sec enabled by default) now looks like:
 ```bash
$ ./hmy transfer --from one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --to one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --from-shard 0 --to-shard 1 --amount 1  --node=https://api.s0.b.hmny.io/
{
  "transaction-hash": "0x0c3baad22222cece3052c55a5b67fcc656902993d802e22e8f8b654a3ac34a0b",
  "blockchain-receipt": {
    "blockHash": "0x0b52bd0a60b7a7105d5429d30c16f1e5f1645ad7c4157659552713d9a5c422f3",
    "blockNumber": "0x3a557",
    "contractAddress": null,
    "cumulativeGasUsed": "0x5208",
    "from": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
    "gasUsed": "0x5208",
    "logs": [],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "shardID": 0,
    "status": "0x1",
    "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
    "transactionHash": "0x0c3baad22222cece3052c55a5b67fcc656902993d802e22e8f8b654a3ac34a0b",
    "transactionIndex": "0x0"
  },
  "time-signed-utc": "2020-02-15 08:54:08.807241"
}
```

A failed transaction (with timeout 40 sec by default) now looks like
```bash
$ ./hmy transfer --from one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --to one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --from-shard 0 --to-shard 1 --amount 1  --node=https://api.s0.b.hmny.io/ --nonce 0
{
  "errors": [
    "[2020-02-15 08:56:50.557872] [Plain transaction] transaction nonce is 0: nonce too low -- 2020-02-15 00:56:06 -0800 PST",
    "[2020-02-15 08:56:50.557881] Failed to confirm transaction"
  ],
  "time-signed-utc": "2020-02-15 08:56:06.354166"
}
commit: v276-fd39f55, error: Failed to confirm transaction
check hmy cookbook for valid examples or try adding a `--help` flag
```

A transaction without timeout (sends without checking if it finalized)
```bash
$ ./hmy transfer --from one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --to one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur --from-shard 0 --to-shard 1 --amount 1  --node=https://api.s0.b.hmny.io/ --timeout 0
{
  "transaction-hash": "0xd5a4cd38436091d32103e16f1946fbf44bba2b9edf7fbee6486beec5a784a8b4",
  "time-signed-utc": "2020-02-15 08:57:42.441481"
}
```
