### PR TITLE
[#2296] Make recover-from-mnemonic a separate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,22 +52,22 @@ Note:
 Examples:
 
 1.  Check account balance on given chain
-hmy --node="https://api.s1.p.hmny.io/" balances <SOME_ONE_ADDRESS>
+hmy --node="https://api.s1.t.hmny.io/" balances <SOME_ONE_ADDRESS>
 
 2.  Check sent transaction
-hmy --node="https://api.s1.p.hmny.io" blockchain transaction-by-hash <SOME_TX_HASH>
+hmy --node="https://api.s1.t.hmny.io" blockchain transaction-by-hash <SOME_TX_HASH>
 
 3.  List local account keys
 hmy keys list
 
-4.  Sending a transaction (add `--wait-for-confirm=10` to wait 10 seconds for confirmation)
-hmy --node="https://api.s1.p.hmny.io/" transfer \
+4.  Sending a transaction (waits 40 seconds for transaction confirmation)
+hmy --node="https://api.s1.t.hmny.io/" transfer \
     --from one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw \
     --to one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6 \
     --from-shard 0 --to-shard 1 --amount 200
 
-5.  Sending a batch of transactions as dictated from a file (the `--wait-for-confirm` and `--dry-run` options still apply)
-hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
+5.  Sending a batch of transactions as dictated from a file (the `--dry-run` options still apply)
+hmy --node="https://api.s1.t.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
 
     Example of JSON file format:
       [
@@ -78,7 +78,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
           "to-shard": "0",
           "amount": "1",
           "passphrase-string": "",
-          "nonce": "-1",
+          "nonce": "1",
           "stop-on-error": true
         },
         {
@@ -92,7 +92,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
       ]
 
 6.  Check a completed transaction receipt
-hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
+hmy --node="https://api.s1.t.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
 7.  Import an account using the mnemonic. Prompts the user to give the mnemonic.
 hmy keys recover-from-mnemonic <ACCOUNT_NAME>
@@ -110,40 +110,43 @@ hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
 hmy keys generate-bls-key --bls-file-path /tmp/file.key
 
 12. Create a new validator with a list of BLS keys
-hmy --node="https://api.s1.p.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
+hmy --node="https://api.s0.t.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
     --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase
 
 13. Edit an existing validator
-hmy --node="https://api.s1.p.hmny.io" staking edit-validator \
+hmy --node="https://api.s0.t.hmny.io" staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
     --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase
 
 14. Delegate an amount to a validator
-hmy --node="https://api.s1.p.hmny.io" staking delegate \
+hmy --node="https://api.s0.t.hmny.io" staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 15. Undelegate to a validator
-hmy --node="https://api.s1.p.hmny.io" staking undelegate \
+hmy --node="https://api.s0.t.hmny.io" staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 16. Collect block rewards as a delegator
-hmy --node="https://api.s1.p.hmny.io" staking collect-rewards \
+hmy --node="https://api.s0.t.hmny.io" staking collect-rewards \
     --delegator-addr <SOME_ONE_ADDRESS> --passphrase
 
 17. Check active validators
-hmy --node="https://api.s1.p.hmny.io" blockchain validator all-active
+hmy --node="https://api.s0.t.hmny.io" blockchain validator all-active
 
 18. Get current staking utility metrics
-hmy --node="https://api.s0.p.hmny.io" blockchain utility-metrics
+hmy --node="https://api.s0.t.hmny.io" blockchain utility-metrics
 
 19. Check in-memory record of failed staking transactions
 hmy failures staking
+
+20. Check which shard your BLS public key would be assigned to as a validator
+hmy utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b160371cc3c18b8c4977bd3dcb71fd57dc62bf0e143fd08
 ```
 
 # Sending batched transactions
@@ -154,7 +157,7 @@ off **in sequential order**.
 
 Example:
 ```
-hmy --node="https://api.s1.p.hmny.io/" transfer --file ./batchTransactions.json
+hmy --node="https://api.s1.t.hmny.io/" transfer --file ./batchTransactions.json
 ```
 
 > Note that the `--wait-for-confirm` and `--dry-run` options still apply when sending batched transactions

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
 hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
 7.  Import an account using the mnemonic. Prompts the user to give the mnemonic.
-hmy keys add --recover
+hmy keys recover-from-mnemonic <ACCOUNT_NAME>
 
 8.  Import an existing keystore file
 hmy keys import-ks <PATH_TO_KEYSTORE_JSON>.key
@@ -150,12 +150,12 @@ hmy failures staking
 
 One may find it useful to send a batch of transaction with 1 instance of the binary.
 To do this, one can specify a JSON file with the `transaction` subcommand to dictate a batch of transaction to send
-off **in sequential order**. 
+off **in sequential order**.
 
 Example:
 ```
 hmy --node="https://api.s1.p.hmny.io/" transfer --file ./batchTransactions.json
-``` 
+```
 
 > Note that the `--wait-for-confirm` and `--dry-run` options still apply when sending batched transactions
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func main() {
 	cmd.RootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Show version",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE:  func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr,
 				"Harmony (C) 2020. %v, version %v-%v (%v %v)\n",
 				path.Base(os.Args[0]), version, commit, builtBy, builtAt)

--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -111,7 +111,7 @@ func keysSub() []*cobra.Command {
 				Passphrase: passphrase,
 			}
 			if recoverFromMnemonic {
-				color.Red("{Deprecated method} Use ./hmy keys recover-from-mnemonic instead.")
+				fmt.Fprintf(os.Stderr, "deprecated method: use `./hmy keys recover-from-mnemonic` instead.\n")
 				fmt.Println("Enter mnemonic to recover keys from")
 				scanner := bufio.NewScanner(os.Stdin)
 				scanner.Scan()

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -21,8 +21,8 @@ Note:
 1) Every subcommand recognizes a '--help' flag
 2) If a passphrase is used by a subcommand, one can enter their own passphrase interactively
    with the --passphrase option. Alternatively, one can pass their own passphrase via a file
-   using the --passphrase-file option. If no passphrase option is selected, the default 
-   passphrase of '' is used.   
+   using the --passphrase-file option. If no passphrase option is selected, the default
+   passphrase of '' is used.
 3) These examples use shard 1 of testnet as argument for --node
 
 Examples:
@@ -44,7 +44,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer \
 
 %s
 hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
-    
+
     Example of JSON file format:
       [
         {
@@ -71,7 +71,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
 hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
 %s
-hmy keys add --recover
+hmy keys recover-from-mnemonic <ACCOUNT_NAME>
 
 %s
 hmy keys import-ks <PATH_TO_KEYSTORE_JSON>.key
@@ -89,28 +89,28 @@ hmy keys generate-bls-key --bls-file-path /tmp/file.key
 hmy --node="https://api.s1.p.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
-    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase 
+    --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
-    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase 
+    --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase 
+    --amount 10 --passphrase
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
-    --amount 10 --passphrase 
+    --amount 10 --passphrase
 
 %s
 hmy --node="https://api.s1.p.hmny.io" staking collect-rewards \
-    --delegator-addr <SOME_ONE_ADDRESS> --passphrase 
+    --delegator-addr <SOME_ONE_ADDRESS> --passphrase
 
 %s
 hmy --node="https://api.s1.p.hmny.io" blockchain validator elected

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -28,22 +28,22 @@ Note:
 Examples:
 
 %s
-hmy --node="https://api.s1.p.hmny.io/" balances <SOME_ONE_ADDRESS>
+hmy --node="https://api.s1.t.hmny.io/" balances <SOME_ONE_ADDRESS>
 
 %s
-hmy --node="https://api.s1.p.hmny.io" blockchain transaction-by-hash <SOME_TX_HASH>
+hmy --node="https://api.s1.t.hmny.io" blockchain transaction-by-hash <SOME_TX_HASH>
 
 %s
 hmy keys list
 
 %s
-hmy --node="https://api.s1.p.hmny.io/" transfer \
+hmy --node="https://api.s1.t.hmny.io/" transfer \
     --from one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw \
     --to one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6 \
     --from-shard 0 --to-shard 1 --amount 200
 
 %s
-hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
+hmy --node="https://api.s1.t.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
 
     Example of JSON file format:
       [
@@ -68,7 +68,7 @@ hmy --node="https://api.s1.p.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
       ]
 
 %s
-hmy --node="https://api.s1.p.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
+hmy --node="https://api.s1.t.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
 
 %s
 hmy keys recover-from-mnemonic <ACCOUNT_NAME>
@@ -86,34 +86,37 @@ hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
 hmy keys generate-bls-key --bls-file-path /tmp/file.key
 
 %s
-hmy --node="https://api.s1.p.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
+hmy --node="https://api.s0.t.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
     --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase
 
 %s
-hmy --node="https://api.s1.p.hmny.io" staking edit-validator \
+hmy --node="https://api.s0.t.hmny.io" staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
     --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase
 
 %s
-hmy --node="https://api.s1.p.hmny.io" staking delegate \
+hmy --node="https://api.s0.t.hmny.io" staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 %s
-hmy --node="https://api.s1.p.hmny.io" staking undelegate \
+hmy --node="https://api.s0.t.hmny.io" staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 %s
-hmy --node="https://api.s1.p.hmny.io" staking collect-rewards \
+hmy --node="https://api.s0.t.hmny.io" staking collect-rewards \
     --delegator-addr <SOME_ONE_ADDRESS> --passphrase
 
 %s
-hmy --node="https://api.s1.p.hmny.io" blockchain validator elected
+hmy --node="https://api.s0.t.hmny.io" blockchain validator elected
+
+%s
+hmy --node="https://api.s0.t.hmny.io" blockchain utility-metrics
 
 %s
 hmy failures staking
@@ -125,8 +128,8 @@ hmy utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b1603
 		g("1.  Check account balance on given chain"),
 		g("2.  Check sent transaction"),
 		g("3.  List local account keys"),
-		g("4.  Sending a transaction (add `--wait-for-confirm=10` to wait 10 seconds for confirmation)"),
-		g("5.  Sending a batch of transactions as dictated from a file (the `--wait-for-confirm` and `--dry-run` options still apply)"),
+		g("4.  Sending a transaction (waits 40 seconds for transaction confirmation)"),
+		g("5.  Sending a batch of transactions as dictated from a file (the `--dry-run` options still apply)"),
 		g("6.  Check a completed transaction receipt"),
 		g("7.  Import an account using the mnemonic. Prompts the user to give the mnemonic."),
 		g("8.  Import an existing keystore file"),
@@ -139,7 +142,8 @@ hmy utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b1603
 		g("15. Undelegate to a validator"),
 		g("16. Collect block rewards as a delegator"),
 		g("17. Check elected validators"),
-		g("18. Check in-memory record of failed staking transactions"),
-		g("19. Check which shard your BLS public key would be assigned to as a validator"),
+		g("18. Get current staking utility metrics"),
+		g("19. Check in-memory record of failed staking transactions"),
+		g("20. Check which shard your BLS public key would be assigned to as a validator"),
 	)
 )


### PR DESCRIPTION
```
deprecated method: use `./hmy keys recover-from-mnemonic` instead.
```