### PR TITLE
patch node leniency to handle endpoints

### DIFF
--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -49,7 +49,9 @@ var (
 			if verbose {
 				common.EnableAllVerbose()
 			}
-			if strings.HasPrefix(node, "api") || strings.HasPrefix(node, "ws") {
+			if strings.HasPrefix(node, "https://") {
+				//No op, already has protocol, should be endpoint
+			} else if strings.HasPrefix(node, "api") || strings.HasPrefix(node, "ws") {
 				node = "https://" + node
 			} else {
 				switch URLcomponents := strings.Split(node, ":"); len(URLcomponents) {


### PR DESCRIPTION
- Previous logic did not account for passing an endpoint with a protocol as node.
  - https://api.s0.os.hmny.io/ would fail
- Added a check for TLS protocol. 