### PR TITLE
[#180] Better error message for validator information not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ ldflags := -X main.version=v${version} -X main.commit=${commit}
 ldflags += -X main.builtAt=${built_at} -X main.builtBy=${built_by}
 cli := ./dist/hmy
 upload-path-darwin := 's3://pub.harmony.one/release/darwin-x86_64/mainnet/hmy'
-upload-path-darwin-version := 's3://pub.harmony.one/release/darwin-x86_64/mainnet/hmy_version'
 upload-path-linux := 's3://pub.harmony.one/release/linux-x86_64/mainnet/hmy'
 upload-path-linux-version := 's3://pub.harmony.one/release/linux-x86_64/mainnet/hmy_version'
 
@@ -46,9 +45,8 @@ test-rpc:
 # Notice assumes you have correct uploading credentials
 upload-darwin:all
 	aws --profile upload s3 cp ./hmy ${upload-path-darwin}
-	./hmy version &> ./hmy_version
-	aws --profile upload s3 cp ./hmy_version ${upload-path-darwin-version}
 
+# Only the linux build will upload the CLI version
 upload-linux:static
 	aws --profile upload s3 cp ./hmy ${upload-path-linux}
 	./hmy version &> ./hmy_version

--- a/cmd/subcommands/validator.go
+++ b/cmd/subcommands/validator.go
@@ -43,7 +43,11 @@ var (
 		PreRunE: validateAddress,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			noLatest = true
-			return request(rpc.Method.GetValidatorInformation, []interface{}{addr.address})
+			e := request(rpc.Method.GetValidatorInformation, []interface{}{addr.address})
+			if e != nil {
+				return fmt.Errorf("validator address not found: %s", addr.address)
+			}
+			return e
 		},
 	}, {
 		Use:     "information-by-block-number",


### PR DESCRIPTION
```
$ hmyStaking blockchain validator information one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur
commit: v342-7dbc13e-dirty, error: validator address not found: one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur
check hmy cookbook for valid examples or try adding a `--help` flag
```