### PR TITLE
[hmcli] add --bls-pubkeys-dir option

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -52,6 +52,7 @@ var (
 	minSelfDelegation         string
 	maxTotalDelegation        string
 	stakingBlsPubKeys         []string
+	blsPubKeyDir              string
 	delegatorAddress          oneAddress
 	validatorAddress          oneAddress
 	stakingAmount             string
@@ -326,7 +327,7 @@ Create a new validator"
 				blsPubKeys[i].FromLibBLSPublicKey(blsPubKey)
 			}
 
-			blsSigs, err := keys.VerifyBLSKeys(stakingBlsPubKeys)
+			blsSigs, err := keys.VerifyBLSKeys(stakingBlsPubKeys, blsPubKeyDir)
 			if err != nil {
 				return err
 			}
@@ -427,6 +428,7 @@ Create a new validator"
 		&stakingBlsPubKeys, "bls-pubkeys",
 		[]string{}, "validator's list of public BLS key addresses",
 	)
+	subCmdNewValidator.Flags().StringVar(&blsPubKeyDir, "bls-pubkeys-dir", "", "directory to bls pubkeys storing pub.key, pub.pass files")
 	subCmdNewValidator.Flags().StringVar(&stakingAmount, "amount", "0.0", "staking amount")
 	subCmdNewValidator.Flags().StringVar(&gasPrice, "gas-price", "1", "gas price to pay")
 	subCmdNewValidator.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")
@@ -494,7 +496,7 @@ Create a new validator"
 				shardKey.FromLibBLSPublicKey(blsKey)
 				shardPubKeyAdd = &shardKey
 
-				sig, err := keys.VerifyBLS(strings.TrimPrefix(slotKeyToAdd, "0x"))
+				sig, err := keys.VerifyBLS(strings.TrimPrefix(slotKeyToAdd, "0x"), blsPubKeyDir)
 				if err != nil {
 					return err
 				}

--- a/pkg/common/values.go
+++ b/pkg/common/values.go
@@ -22,6 +22,8 @@ var (
 	DebugTransaction = false
 	ErrNotAbsPath    = errors.New("keypath is not absolute path")
 	ErrBadKeyLength  = errors.New("Invalid private key (wrong length)")
+	ErrFoundNoKey    = errors.New("found no bls key file")
+	ErrFoundNoPass   = errors.New("found no passphrase file")
 )
 
 func init() {


### PR DESCRIPTION
This option can be used to automate the create-validator and
edit-validator actions. No need to manually input the path to the
blskeys and the passphrase.

--bls-pubkeys-dir <path> is used to specify the path to the bls pubkey
files and the passphrase files

the pubkey and passphrase files should follow the naming convention of
pubkey.key and pubkey.pass as a pair.

Signed-off-by: Leo Chen <leo@harmony.one>