### PR TITLE
[blockchain] Add latest-headers command to get chain headers

### DIFF
--- a/cmd/subcommands/blockchain.go
+++ b/cmd/subcommands/blockchain.go
@@ -163,6 +163,13 @@ High level information about transaction, like blockNumber, blockHash
 			return request(rpc.Method.GetLatestBlockHeader, []interface{}{})
 		},
 	}, {
+		Use:   "latest-headers",
+		Short: "Get the latest chain headers",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			noLatest = true
+			return request(rpc.Method.GetLatestChainHeaders, []interface{}{})
+		},
+	}, {
 		Use:   "resend-cx",
 		Short: "Re-play a cross shard transaction",
 		Args:  cobra.ExactArgs(1),

--- a/pkg/rpc/methods.go
+++ b/pkg/rpc/methods.go
@@ -70,6 +70,7 @@ type rpcEnumList struct {
 	GetCurrentBadBlocks                     method
 	GetShardID                              method
 	GetLastCrossLinks                       method
+	GetLatestChainHeaders                   method
 }
 
 // Method is a list of known RPC methods
@@ -132,6 +133,7 @@ var Method = rpcEnumList{
 	GetCurrentBadBlocks:                     "hmy_getCurrentBadBlocks",
 	GetShardID:                              "hmy_getShardID",
 	GetLastCrossLinks:                       "hmy_getLastCrossLinks",
+	GetLatestChainHeaders:                   "hmy_getLatestChainHeaders",
 }
 
 // TODO Use Reflection here to avoid typing out the cases


### PR DESCRIPTION
```
$ hmy blockchain latest-headers --node=127.0.0.1:9511
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "beacon-chain-header": {
      "block-header-hash": "0xf8fe4304edebe73a4ecd844fb80e0a72d3619ecfd68f7ad7d46b1a1b78deddc1",
      "block-number": 19,
      "epoch": 2,
      "shard-id": 0,
      "view-id": 19
    },
    "shard-chain-header": {
      "block-header-hash": "0x5da27afe7dd61786186998f1959a538dc196438782b6edc34eb7028d43111aad",
      "block-number": 19,
      "epoch": 2,
      "shard-id": 1,
      "view-id": 19
    }
  }
}
```