### PR TITLE
Add node check when generating BLS keys

### DIFF
--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -131,6 +131,9 @@ func init() {
 			} else if chainName.chainID == &common.Chain.PangaeaNet {
 				docNode = `https://api.s0.os.hmny.io`
 				docNet = `Open Staking Network`
+			} else if chainName.chainID == &common.Chain.PartnerNet {
+				docNode = `https://api.s0.ps.hmny.io`
+				docNet = `Partner Testnet`
 			} else if chainName.chainID == &common.Chain.StressNet {
 				docNode = `https://api.s0.stn.hmny.io`
 				docNet = `Stress Testing Network`
@@ -193,6 +196,8 @@ func endpointToChainID(nodeAddr string) chainIDWrapper {
 		return chainIDWrapper{chainID: &common.Chain.TestNet}
 	} else if strings.Contains(nodeAddr, ".os.") {
 		return chainIDWrapper{chainID: &common.Chain.PangaeaNet}
+	} else if strings.Contains(nodeAddr, ".ps.") {
+		return chainIDWrapper{chainID: &common.Chain.PartnerNet}
 	} else if strings.Contains(nodeAddr, ".stn.") {
 		return chainIDWrapper{chainID: &common.Chain.StressNet}
 	}

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"fmt"
 
-	color "github.com/fatih/color"
+	"github.com/fatih/color"
 )
 
 const (
-	hmyDocsDir      = "hmy-docs"
-	defaultNodeAddr = "http://localhost:9500"
+	hmyDocsDir             = "hmy-docs"
+	defaultNodeAddr        = "http://localhost:9500"
+	defaultMainnetEndpoint = "https://api.s0.t.hmny.io/"
 )
 
 var (

--- a/pkg/common/chain-id.go
+++ b/pkg/common/chain-id.go
@@ -16,6 +16,7 @@ type chainIDList struct {
 	MainNet    ChainID `json:"mainnet"`
 	TestNet    ChainID `json:"testnet"`
 	PangaeaNet ChainID `json:"pangaea"`
+	PartnerNet ChainID `json:"partner"`
 	StressNet  ChainID `json:"stress"`
 }
 
@@ -24,6 +25,7 @@ var Chain = chainIDList{
 	MainNet:    ChainID{"mainnet", big.NewInt(1)},
 	TestNet:    ChainID{"testnet", big.NewInt(2)},
 	PangaeaNet: ChainID{"pangaea", big.NewInt(3)},
+	PartnerNet: ChainID{"partner", big.NewInt(4)},
 	StressNet:  ChainID{"stress", big.NewInt(5)},
 }
 
@@ -41,6 +43,10 @@ func StringToChainID(name string) (*ChainID, error) {
 		return &Chain.TestNet, nil
 	case "pangaea":
 		return &Chain.PangaeaNet, nil
+	case "devnet":
+		return &Chain.PartnerNet, nil
+	case "partner":
+		return &Chain.PartnerNet, nil
 	case "stressnet":
 		return &Chain.StressNet, nil
 	default:

--- a/pkg/keys/bls.go
+++ b/pkg/keys/bls.go
@@ -56,8 +56,8 @@ func (blsKey *BlsKey) Reset() {
 	blsKey.PublicKeyHex = ""
 }
 
-// GenBlsKeys - generate a random bls key using the supplied passphrase, write it to disk at the given filePath
-func GenBlsKeys(blsKey *BlsKey) error {
+// GenBlsKey - generate a random bls key using the supplied passphrase, write it to disk at the given filePath
+func GenBlsKey(blsKey *BlsKey) error {
 	blsKey.Initialize()
 	out, err := writeBlsKeyToFile(blsKey)
 	if err != nil {
@@ -68,26 +68,22 @@ func GenBlsKeys(blsKey *BlsKey) error {
 }
 
 // GenMultiBlsKeys - generate multiple BLS keys for a given shard and node/network
-func GenMultiBlsKeys(blsKeys []*BlsKey, node string, count uint32, shardID uint32) error {
-	blsKeys, _, err := generateMultipleBlsKeys(blsKeys, node, count, shardID)
+func GenMultiBlsKeys(blsKeys []*BlsKey, node string, shardID uint32) error {
+	blsKeys, _, err := genBlsKeyForNode(blsKeys, node, shardID)
 	if err != nil {
 		return err
 	}
-
 	outputs := []string{}
 	for _, blsKey := range blsKeys {
 		out, err := writeBlsKeyToFile(blsKey)
 		if err != nil {
 			return err
 		}
-
 		outputs = append(outputs, out)
 	}
-
 	if len(outputs) > 0 {
 		fmt.Println(common.JSONPrettyFormat(fmt.Sprintf("[%s]", strings.Join(outputs[:], ","))))
 	}
-
 	return nil
 }
 
@@ -338,7 +334,7 @@ func decryptRaw(data []byte, passphrase string) ([]byte, error) {
 	return plaintext, err
 }
 
-func generateMultipleBlsKeys(blsKeys []*BlsKey, node string, count uint32, shardID uint32) ([]*BlsKey, int, error) {
+func genBlsKeyForNode(blsKeys []*BlsKey, node string, shardID uint32) ([]*BlsKey, int, error) {
 	shardingStructure, err := sharding.Structure(node)
 	if err != nil {
 		return blsKeys, -1, err

--- a/pkg/keys/bls_test.go
+++ b/pkg/keys/bls_test.go
@@ -23,7 +23,7 @@ func TestBlsKeyGeneration(t *testing.T) {
 		t.Errorf("TestBlsKeyGeneration - failed to make test key folder")
 	}
 
-	if err := GenBlsKeys(&BlsKey{Passphrase: passphrase, FilePath: absFilePath}); err != nil {
+	if err := GenBlsKey(&BlsKey{Passphrase: passphrase, FilePath: absFilePath}); err != nil {
 		t.Errorf("TestBlsKeyGeneration - failed to generate bls key using passphrase %s and path %s", passphrase, absFilePath)
 	}
 
@@ -34,7 +34,7 @@ func TestBlsKeyGeneration(t *testing.T) {
 	valid = !os.IsNotExist(err)
 
 	if !valid {
-		t.Errorf("GenBlsKeys - failed to generate a bls key using passphrase %s", "")
+		t.Errorf("GenBlsKey - failed to generate a bls key using passphrase %s", "")
 	}
 
 	os.RemoveAll(absFolderPath)
@@ -48,16 +48,7 @@ func TestMultiBlsKeyGeneration(t *testing.T) {
 		filePath string
 		expected bool
 	}{
-		{node: "https://api.s0.os.hmny.io", count: 3, shardID: 0, expected: true},
-		{node: "https://api.s0.ps.hmny.io", count: 3, shardID: 0, expected: true},
-		{node: "https://api.s0.stn.hmny.io", count: 3, shardID: 0, expected: true},
-		{node: "https://api.s0.b.hmny.io", count: 3, shardID: 0, expected: true},
 		{node: "https://api.s0.t.hmny.io", count: 3, shardID: 0, expected: true},
-
-		{node: "https://api.s0.os.hmny.io", count: 3, shardID: 4, expected: false},
-		{node: "https://api.s0.ps.hmny.io", count: 3, shardID: 4, expected: false},
-		{node: "https://api.s0.stn.hmny.io", count: 3, shardID: 4, expected: false},
-		{node: "https://api.s0.b.hmny.io", count: 3, shardID: 4, expected: false},
 		{node: "https://api.s0.t.hmny.io", count: 3, shardID: 4, expected: false},
 	}
 
@@ -68,7 +59,7 @@ func TestMultiBlsKeyGeneration(t *testing.T) {
 			blsKeys = append(blsKeys, &BlsKey{Passphrase: "", FilePath: ""})
 		}
 
-		blsKeys, shardCount, err := generateMultipleBlsKeys(blsKeys, test.node, test.count, test.shardID)
+		blsKeys, shardCount, err := genBlsKeyForNode(blsKeys, test.node, test.shardID)
 		if err != nil {
 			valid = false
 		}
@@ -85,7 +76,7 @@ func TestMultiBlsKeyGeneration(t *testing.T) {
 		valid = (successCount == int(test.count))
 
 		if valid != test.expected {
-			t.Errorf("generateMultipleBlsKeys - failed to generate %d keys for shard %d using node %s", test.count, test.shardID, test.node)
+			t.Errorf("genBlsKeyForNode - failed to generate %d keys for shard %d using node %s", test.count, test.shardID, test.node)
 		}
 	}
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -34,6 +34,9 @@ func TestIsValidAddress(t *testing.T) {
 }
 
 func TestIsValidShard(t *testing.T) {
+	if err := ValidateNodeConnection("http://localhost:9500"); err != nil {
+		t.Skip()
+	}
 	s, _ := sharding.Structure("http://localhost:9500")
 
 	tests := []struct {

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -2,7 +2,9 @@ package validation
 
 import (
 	"fmt"
+	"net"
 	"regexp"
+	"time"
 )
 
 var (
@@ -39,4 +41,11 @@ func ValidShardID(shardID uint32, shardCount uint32) bool {
 	}
 
 	return true
+}
+
+// ValidateNodeConnection validates that the node can be connected to
+func ValidateNodeConnection(node string) error {
+	timeout := time.Duration(1 * time.Second)
+	_, err := net.DialTimeout("tcp", node, timeout)
+	return err
 }


### PR DESCRIPTION
Default to mainnet if the provided node is not alive for BLS keygen.

