### PR TITLE
Use pending nonce over true nonce by default for txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Check README for details on json file format.
 ./hmy --node=https://api.s0.t.hmny.io failures staking
 
 20. Check which shard your BLS public key would be assigned to as a validator
-./hmy --node=https://api.s0.t.hmny.io utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b160371cc3c18b8c4977bd3dcb71fd57dc62bf0e143fd08
+./hmy --node=https://api.s0.t.hmny.io utility shard-for-bls <BLS_PUBLIC_KEY>
 ```
 
 # Sending batched transactions
@@ -156,7 +156,7 @@ The JSON file will be a JSON array where each element has the following attribut
 | `gas-price`         | string     | [*Optional*] The gas price to pay in NANO (1e-9 of $ONE), default is 1. |
 | `gas-limit`         | string     | [*Optional*] The gas limit, default is 21000. |
 | `stop-on-error`     | boolean    | [*Optional*] If true, stop sending transactions if an error occurred, default is false. |
-| `true-nonce`        | boolean    | [*Optional*] If true, send transaction using true on-chain nonce. Cannot be used with `nonce`. If non is provided, use tx pool nonce. |
+| `true-nonce`        | boolean    | [*Optional*] If true, send transaction using true on-chain nonce. Cannot be used with `nonce`. If none is provided, use tx pool nonce. |
 
 Example of JSON file:
 

--- a/README.md
+++ b/README.md
@@ -47,106 +47,84 @@ Note:
    with the --passphrase option. Alternatively, one can pass their own passphrase via a file
    using the --passphrase-file option. If no passphrase option is selected, the default
    passphrase of '' is used.
-3) These examples use shard 1 of Mainnet as argument for --node
+3) These examples use Shard 0 of Mainnet as argument for --node
 
 Examples:
 
 1.  Check account balance on given chain
-hmy --node="https://api.s1.t.hmny.io/" balances <SOME_ONE_ADDRESS>
+./hmy --node=https://api.s0.t.hmny.io balances <SOME_ONE_ADDRESS>
 
 2.  Check sent transaction
-hmy --node="https://api.s1.t.hmny.io" blockchain transaction-by-hash <SOME_TX_HASH>
+./hmy --node=https://api.s0.t.hmny.io blockchain transaction-by-hash <SOME_TX_HASH>
 
 3.  List local account keys
-hmy keys list
+./hmy keys list
 
 4.  Sending a transaction (waits 40 seconds for transaction confirmation)
-hmy --node="https://api.s1.t.hmny.io/" transfer \
-    --from one1yc06ghr2p8xnl2380kpfayweguuhxdtupkhqzw \
-    --to one1q6gkzcap0uruuu8r6sldxuu47pd4ww9w9t7tg6 \
-    --from-shard 0 --to-shard 1 --amount 200
+./hmy --node=https://api.s0.t.hmny.io transfer \
+    --from <SOME_ONE_ADDRESS> --to <SOME_ONE_ADDRESS> \
+    --from-shard 0 --to-shard 1 --amount 200 --passphrase
 
 5.  Sending a batch of transactions as dictated from a file (the `--dry-run` options still apply)
-hmy --node="https://api.s1.t.hmny.io/" transfer --file <PATH_TO_JSON_FILE>
-
-    Example of JSON file format:
-      [
-        {
-          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
-          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
-          "from-shard" : "0",
-          "to-shard": "0",
-          "amount": "1",
-          "passphrase-string": "",
-          "nonce": "1",
-          "stop-on-error": true
-        },
-        {
-          "from": "one103q7qe5t2505lypvltkqtddaef5tzfxwsse4z7",
-          "to": "one1zksj3evekayy90xt4psrz8h6j2v3hla4qwz4ur",
-          "from-shard" : "0",
-          "to-shard": "0",
-          "amount": "1",
-          "passphrase-file": "./pw.txt"
-        }
-      ]
+./hmy --node=https://api.s0.t.hmny.io transfer --file <PATH_TO_JSON_FILE>
+Check README for details on json file format.
 
 6.  Check a completed transaction receipt
-hmy --node="https://api.s1.t.hmny.io" blockchain transaction-receipt <SOME_TX_HASH>
+./hmy --node=https://api.s0.t.hmny.io blockchain transaction-receipt <SOME_TX_HASH>
 
 7.  Import an account using the mnemonic. Prompts the user to give the mnemonic.
-hmy keys recover-from-mnemonic <ACCOUNT_NAME>
+./hmy keys recover-from-mnemonic <ACCOUNT_NAME>
 
 8.  Import an existing keystore file
-hmy keys import-ks <PATH_TO_KEYSTORE_JSON>.key
+./hmy keys import-ks <PATH_TO_KEYSTORE_JSON>
 
 9.  Import a keystore file using a secp256k1 private key
-hmy keys import-private-key <secp256k1_PRIVATE_KEY>
+./hmy keys import-private-key <secp256k1_PRIVATE_KEY>
 
-10.  Export a keystore file's secp256k1 private key
-hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
+10. Export a keystore file's secp256k1 private key
+./hmy keys export-private-key <ACCOUNT_ADDRESS> --passphrase
 
 11. Generate a BLS key then encrypt and save the private key to the specified location.
-hmy keys generate-bls-key --bls-file-path /tmp/file.key
+./hmy keys generate-bls-key --bls-file-path <PATH_FOR_BLS_KEY_FILE>
 
 12. Create a new validator with a list of BLS keys
-hmy --node="https://api.s0.t.hmny.io" staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
+./hmy --node=https://api.s0.t.hmny.io staking create-validator --amount 10 --validator-addr <SOME_ONE_ADDRESS> \
     --bls-pubkeys <BLS_KEY_1>,<BLS_KEY_2>,<BLS_KEY_3> \
     --identity foo --details bar --name baz --max-change-rate 0.1 --max-rate 0.1 --max-total-delegation 10 \
     --min-self-delegation 10 --rate 0.1 --security-contact Leo  --website harmony.one --passphrase
 
 13. Edit an existing validator
-hmy --node="https://api.s0.t.hmny.io" staking edit-validator \
+./hmy --node=https://api.s0.t.hmny.io staking edit-validator \
     --validator-addr <SOME_ONE_ADDRESS> --identity foo --details bar \
     --name baz --security-contact EK --website harmony.one \
     --min-self-delegation 0 --max-total-delegation 10 --rate 0.1\
     --add-bls-key <SOME_BLS_KEY> --remove-bls-key <OTHER_BLS_KEY> --passphrase
 
 14. Delegate an amount to a validator
-hmy --node="https://api.s0.t.hmny.io" staking delegate \
+./hmy --node=https://api.s0.t.hmny.io staking delegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 15. Undelegate to a validator
-hmy --node="https://api.s0.t.hmny.io" staking undelegate \
+./hmy --node=https://api.s0.t.hmny.io staking undelegate \
     --delegator-addr <SOME_ONE_ADDRESS> --validator-addr <VALIDATOR_ONE_ADDRESS> \
     --amount 10 --passphrase
 
 16. Collect block rewards as a delegator
-hmy --node="https://api.s0.t.hmny.io" staking collect-rewards \
+./hmy --node=https://api.s0.t.hmny.io staking collect-rewards \
     --delegator-addr <SOME_ONE_ADDRESS> --passphrase
 
-17. Check active validators
-hmy --node="https://api.s0.t.hmny.io" blockchain validator all-active
+17. Check elected validators
+./hmy --node=https://api.s0.t.hmny.io blockchain validator elected
 
 18. Get current staking utility metrics
-hmy --node="https://api.s0.t.hmny.io" blockchain utility-metrics
+./hmy --node=https://api.s0.t.hmny.io blockchain utility-metrics
 
 19. Check in-memory record of failed staking transactions
-hmy failures staking
+./hmy --node=https://api.s0.t.hmny.io failures staking
 
 20. Check which shard your BLS public key would be assigned to as a validator
-hmy utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b160371cc3c18b8c4977bd3dcb71fd57dc62bf0e143fd08
+./hmy --node=https://api.s0.t.hmny.io utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b160371cc3c18b8c4977bd3dcb71fd57dc62bf0e143fd08
 ```
 
 # Sending batched transactions
@@ -178,6 +156,7 @@ The JSON file will be a JSON array where each element has the following attribut
 | `gas-price`         | string     | [*Optional*] The gas price to pay in NANO (1e-9 of $ONE), default is 1. |
 | `gas-limit`         | string     | [*Optional*] The gas limit, default is 21000. |
 | `stop-on-error`     | boolean    | [*Optional*] If true, stop sending transactions if an error occurred, default is false. |
+| `true-nonce`        | boolean    | [*Optional*] If true, send transaction using true on-chain nonce. Cannot be used with `nonce`. If non is provided, use tx pool nonce. |
 
 Example of JSON file:
 
@@ -201,7 +180,8 @@ Example of JSON file:
     "amount": "1",
     "passphrase-file": "./pw.txt",
     "gas-price": "1",
-    "gas-limit": "21000"
+    "gas-limit": "21000",
+    "true-nonce": true
   }
 ]
 ```

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -388,9 +388,14 @@ Create a new validator"
 				}
 			}
 
-			nonce, err := getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
-			if err != nil {
-				return err
+			var nonce uint64
+			if trueNonce {
+				nonce = transaction.GetNextNonce(validatorAddress.String(), networkHandler)
+			} else {
+				nonce, err = getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
+				if err != nil {
+					return err
+				}
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -410,6 +415,7 @@ Create a new validator"
 		},
 	}
 
+	subCmdNewValidator.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	subCmdNewValidator.Flags().StringVar(&validatorName, "name", "", "validator's name")
 	subCmdNewValidator.Flags().StringVar(&validatorIdentity, "identity", "", "validator's identity")
 	subCmdNewValidator.Flags().StringVar(&validatorWebsite, "website", "", "validator's website")
@@ -571,9 +577,14 @@ Create a new validator"
 				}
 			}
 
-			nonce, err := getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
-			if err != nil {
-				return err
+			var nonce uint64
+			if trueNonce {
+				nonce = transaction.GetNextNonce(validatorAddress.String(), networkHandler)
+			} else {
+				nonce, err = getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
+				if err != nil {
+					return err
+				}
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -593,6 +604,7 @@ Create a new validator"
 		},
 	}
 
+	subCmdEditValidator.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	subCmdEditValidator.Flags().StringVar(&validatorName, "name", "", "validator's name")
 	subCmdEditValidator.Flags().StringVar(&validatorIdentity, "identity", "", "validator's identity")
 	subCmdEditValidator.Flags().StringVar(&validatorWebsite, "website", "", "validator's website")
@@ -646,9 +658,14 @@ Delegating to a validator
 				}
 			}
 
-			nonce, err := getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-			if err != nil {
-				return err
+			var nonce uint64
+			if trueNonce {
+				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
+			} else {
+				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
+				if err != nil {
+					return err
+				}
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -668,6 +685,7 @@ Delegating to a validator
 		},
 	}
 
+	subCmdDelegate.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	subCmdDelegate.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
 	subCmdDelegate.Flags().Var(&validatorAddress, "validator-addr", "validator's address")
 	subCmdDelegate.Flags().StringVar(&stakingAmount, "amount", "0", "staking amount")
@@ -712,9 +730,14 @@ Delegating to a validator
 				}
 			}
 
-			nonce, err := getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-			if err != nil {
-				return err
+			var nonce uint64
+			if trueNonce {
+				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
+			} else {
+				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
+				if err != nil {
+					return err
+				}
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -734,6 +757,7 @@ Delegating to a validator
 		},
 	}
 
+	subCmdUnDelegate.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	subCmdUnDelegate.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
 	subCmdUnDelegate.Flags().Var(&validatorAddress, "validator-addr", "source validator's address")
 	subCmdUnDelegate.Flags().StringVar(&stakingAmount, "amount", "0", "staking amount")
@@ -768,9 +792,14 @@ Collect token rewards
 				}
 			}
 
-			nonce, err := getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-			if err != nil {
-				return err
+			var nonce uint64
+			if trueNonce {
+				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
+			} else {
+				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
+				if err != nil {
+					return err
+				}
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -790,6 +819,7 @@ Collect token rewards
 		},
 	}
 
+	subCmdCollectRewards.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	subCmdCollectRewards.Flags().Var(&delegatorAddress, "delegator-addr", "delegator's address")
 	subCmdCollectRewards.Flags().StringVar(&gasPrice, "gas-price", "1", "gas price to pay")
 	subCmdCollectRewards.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")

--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -388,14 +388,9 @@ Create a new validator"
 				}
 			}
 
-			var nonce uint64
-			if trueNonce {
-				nonce = transaction.GetNextNonce(validatorAddress.String(), networkHandler)
-			} else {
-				nonce, err = getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
-				if err != nil {
-					return err
-				}
+			nonce, err := getNonce(validatorAddress.String(), networkHandler)
+			if err != nil {
+				return err
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -577,14 +572,9 @@ Create a new validator"
 				}
 			}
 
-			var nonce uint64
-			if trueNonce {
-				nonce = transaction.GetNextNonce(validatorAddress.String(), networkHandler)
-			} else {
-				nonce, err = getNonceFromInput(validatorAddress.String(), inputNonce, networkHandler)
-				if err != nil {
-					return err
-				}
+			nonce, err := getNonce(validatorAddress.String(), networkHandler)
+			if err != nil {
+				return err
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -658,14 +648,9 @@ Delegating to a validator
 				}
 			}
 
-			var nonce uint64
-			if trueNonce {
-				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
-			} else {
-				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-				if err != nil {
-					return err
-				}
+			nonce, err := getNonce(delegatorAddress.String(), networkHandler)
+			if err != nil {
+				return err
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -730,14 +715,9 @@ Delegating to a validator
 				}
 			}
 
-			var nonce uint64
-			if trueNonce {
-				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
-			} else {
-				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-				if err != nil {
-					return err
-				}
+			nonce, err := getNonce(delegatorAddress.String(), networkHandler)
+			if err != nil {
+				return err
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {
@@ -792,14 +772,9 @@ Collect token rewards
 				}
 			}
 
-			var nonce uint64
-			if trueNonce {
-				nonce = transaction.GetNextNonce(delegatorAddress.String(), networkHandler)
-			} else {
-				nonce, err = getNonceFromInput(delegatorAddress.String(), inputNonce, networkHandler)
-				if err != nil {
-					return err
-				}
+			nonce, err := getNonce(delegatorAddress.String(), networkHandler)
+			if err != nil {
+				return err
 			}
 			stakingTx, err := createStakingTransaction(nonce, delegateStakePayloadMaker)
 			if err != nil {

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -33,6 +33,7 @@ var (
 	targetChain       string
 	chainName         chainIDWrapper
 	dryRun            bool
+	trueNonce         bool
 	inputNonce        string
 	gasPrice          string
 	gasLimit          string
@@ -62,6 +63,7 @@ type transferFlags struct {
 	GasPrice         *string `json:"gas-price"`
 	GasLimit         *string `json:"gas-limit"`
 	StopOnError      bool    `json:"stop-on-error"`
+	TrueNonce        bool    `json:"true-nonce"`
 }
 
 func handlerForShard(senderShard uint32, node string) (*rpc.HTTPMessenger, error) {
@@ -122,13 +124,18 @@ func handlerForTransaction(txLog *transactionLog) error {
 		ctrlr = transaction.NewController(networkHandler, ks, acct, *chainName.chainID, opts)
 	}
 
-	nonce, err := getNonceFromInput(fromAddress.String(), inputNonce, networkHandler)
-	if handlerForError(txLog, err) != nil {
-		return err
+	var nonce uint64
+	if trueNonce {
+		nonce = transaction.GetNextNonce(fromAddress.String(), networkHandler)
+	} else {
+		nonce, err = getNonceFromInput(fromAddress.String(), inputNonce, networkHandler)
+		if handlerForError(txLog, err) != nil {
+			return err
+		}
 	}
 
 	amt, err := common.NewDecFromString(amount)
-	if err != nil  {
+	if err != nil {
 		amtErr := fmt.Errorf("amount %w", err)
 		handlerForError(txLog, amtErr)
 		return amtErr
@@ -251,6 +258,7 @@ func handlerForBulkTransactions(txLog *transactionLog, index int) error {
 	} else {
 		gasLimit = "" // Reset to default for subsequent transactions
 	}
+	trueNonce = txnFlags.TrueNonce
 
 	return handlerForTransaction(txLog)
 }
@@ -279,7 +287,7 @@ func getNonceFromInput(addr, inputNonce string, messenger rpc.T) (uint64, error)
 			return nonce, nil
 		}
 	} else {
-		return transaction.GetNextNonce(addr, messenger), nil
+		return transaction.GetNextPendingNonce(addr, messenger), nil
 	}
 }
 
@@ -318,6 +326,9 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 				for _, flagName := range [...]string{"from", "to", "amount", "from-shard", "to-shard"} {
 					_ = cmd.MarkFlagRequired(flagName)
 				}
+				if trueNonce && inputNonce != "" {
+					return fmt.Errorf("cannot specify nonce when using true on-chain nonce")
+				}
 			} else {
 				data, err := ioutil.ReadFile(givenFilePath)
 				if err != nil {
@@ -326,6 +337,11 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 				err = json.Unmarshal(data, &transferFileFlags)
 				if err != nil {
 					return err
+				}
+				for i, batchTx := range transferFileFlags {
+					if batchTx.TrueNonce && batchTx.InputNonce != nil {
+						return fmt.Errorf("cannot specify nonce when using true on-chain nonce for transaction number %v in batch", i+1)
+					}
 				}
 			}
 			return nil
@@ -369,6 +385,7 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 	cmdTransfer.Flags().Var(&fromAddress, "from", "sender's one address, keystore must exist locally")
 	cmdTransfer.Flags().Var(&toAddress, "to", "the destination one address")
 	cmdTransfer.Flags().BoolVar(&dryRun, "dry-run", false, "do not send signed transaction")
+	cmdTransfer.Flags().BoolVar(&trueNonce, "true-nonce", false, "send transaction with on-chain nonce")
 	cmdTransfer.Flags().StringVar(&amount, "amount", "0", "amount to send (ONE)")
 	cmdTransfer.Flags().StringVar(&gasPrice, "gas-price", "1", "gas price to pay (NANO)")
 	cmdTransfer.Flags().StringVar(&gasLimit, "gas-limit", "", "gas limit")

--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -124,14 +124,9 @@ func handlerForTransaction(txLog *transactionLog) error {
 		ctrlr = transaction.NewController(networkHandler, ks, acct, *chainName.chainID, opts)
 	}
 
-	var nonce uint64
-	if trueNonce {
-		nonce = transaction.GetNextNonce(fromAddress.String(), networkHandler)
-	} else {
-		nonce, err = getNonceFromInput(fromAddress.String(), inputNonce, networkHandler)
-		if handlerForError(txLog, err) != nil {
-			return err
-		}
+	nonce, err := getNonce(fromAddress.String(), networkHandler)
+	if err != nil {
+		return err
 	}
 
 	amt, err := common.NewDecFromString(amount)
@@ -273,6 +268,14 @@ func opts(ctlr *transaction.Controller) {
 	if timeout > 0 {
 		ctlr.Behavior.ConfirmationWaitTime = timeout
 	}
+}
+
+func getNonce(address string, messenger rpc.T) (uint64, error) {
+	if trueNonce {
+		// cannot define nonce when using true nonce
+		return transaction.GetNextNonce(address, messenger), nil
+	}
+	return getNonceFromInput(address, inputNonce, messenger)
 }
 
 func getNonceFromInput(addr, inputNonce string, messenger rpc.T) (uint64, error) {

--- a/cmd/subcommands/values.go
+++ b/cmd/subcommands/values.go
@@ -101,7 +101,7 @@ Check README for details on json file format.
 ./hmy --node=[NODE] failures staking
 
 %s
-./hmy --node=[NODE] utility shard-for-bls 2d61379e44a772e5757e27ee2b3874254f56073e6bd226eb8b160371cc3c18b8c4977bd3dcb71fd57dc62bf0e143fd08
+./hmy --node=[NODE] utility shard-for-bls <BLS_PUBLIC_KEY>
 
 `,
 		g("1.  Check account balance on given chain"),

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -20,9 +20,24 @@ func NewTransaction(
 	return types.NewCrossShardTransaction(nonce, &to, shardID, toShardID, amount.TruncateInt(), gasLimit, gasPrice.TruncateInt(), data[:])
 }
 
+// GetNextNonce returns the nonce on-chain (finalized transactions)
 func GetNextNonce(addr string, messenger rpc.T) uint64 {
 	transactionCountRPCReply, err :=
 		messenger.SendRPC(rpc.Method.GetTransactionCount, []interface{}{address.Parse(addr), "latest"})
+
+	if err != nil {
+		return 0
+	}
+
+	transactionCount, _ := transactionCountRPCReply["result"].(string)
+	n, _ := big.NewInt(0).SetString(transactionCount[2:], 16)
+	return n.Uint64()
+}
+
+// GetNextPendingNonce returns the nonce from the tx-pool (un-finalized transactions)
+func GetNextPendingNonce(addr string, messenger rpc.T) uint64 {
+	transactionCountRPCReply, err :=
+		messenger.SendRPC(rpc.Method.GetTransactionCount, []interface{}{address.Parse(addr), "pending"})
 
 	if err != nil {
 		return 0


### PR DESCRIPTION
Using the pending nonce allows for fast consecutive transfers when using the batch transaction file or if using `--timeout 0` flag. However, should one want to use the true nonce (from finalized transactions, i.e: the old way) the `--true-nonce` option has been added to do just that. 