### PR TITLE
Use latest harmony-one/harmony version, use new types.Transaction API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,12 @@ require (
 	github.com/cosmos/cosmos-sdk v0.37.0
 	github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f // indirect
 	github.com/deckarep/golang-set v1.7.1
-	github.com/ethereum/go-ethereum v1.9.21
+	github.com/ethereum/go-ethereum v1.9.23
 	github.com/fatih/color v1.9.0
+	github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26 // indirect
 	github.com/gorilla/handlers v1.4.0 // indirect
 	github.com/harmony-one/bls v0.0.7-0.20191214005344-88c23f91a8a9
-	github.com/harmony-one/harmony v1.10.1-0.20210118195726-e5252cf15909
+	github.com/harmony-one/harmony v1.10.2-0.20210122034820-6112100ef5a1
 	github.com/iancoleman/strcase v0.0.0-20190422225806-e506e3ef7365 // indirect
 	github.com/ipfs/go-todocounter v0.0.2 // indirect
 	github.com/jackpal/gateway v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/harmony-one/harmony v1.10.0 h1:aRodfVU6gbzLXyXwzj8Ht1khvyRgT3SAT1u/Ha
 github.com/harmony-one/harmony v1.10.0/go.mod h1:Vie4EPb3ofZ8llU8tWC3LrsntfX5f8kryJ9EqLZGk4g=
 github.com/harmony-one/harmony v1.10.1-0.20210118195726-e5252cf15909 h1:UUAza3XTlzx64uPX0OT4tJu0P1GOrVBeNqCnEhkgkDs=
 github.com/harmony-one/harmony v1.10.1-0.20210118195726-e5252cf15909/go.mod h1:Vie4EPb3ofZ8llU8tWC3LrsntfX5f8kryJ9EqLZGk4g=
+github.com/harmony-one/harmony v1.10.2-0.20210122034820-6112100ef5a1 h1:cWg7GEVu1a+XO2PCJUJKC10m+8aeTsL9B84pTjqPovo=
+github.com/harmony-one/harmony v1.10.2-0.20210122034820-6112100ef5a1/go.mod h1:QsUfRGisvY6k1KvpzVeBI3VBdHhYLlpVQTEbzrMmw1U=
 github.com/harmony-one/taggedrlp v0.1.2 h1:lAHV4UhBE45W+i7duAAWOgaQNUjDIG6rUydz/5Oqric=
 github.com/harmony-one/taggedrlp v0.1.2/go.mod h1:AK7o802368ESS3v4WZI5DzaHv9q0CsdgR9jPVJ6zleg=
 github.com/harmony-one/taggedrlp v0.1.4 h1:RZ+qy0VCzT+d/mTfq23gH3an5tSvxOhg6AddLDO6tKw=

--- a/pkg/ledger/hw_wallet.go
+++ b/pkg/ledger/hw_wallet.go
@@ -3,12 +3,13 @@ package ledger
 import (
 	"bytes"
 	"fmt"
-	"github.com/pkg/errors"
-	"golang.org/x/crypto/sha3"
 	"log"
 	"math/big"
 	"os"
 	"sync"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/sha3"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -70,7 +71,7 @@ func SignTx(tx *types.Transaction, chainID *big.Int) ([]byte, string, error) {
 			[]interface{}{
 				tx.Nonce(),
 				tx.GasPrice(),
-				tx.Gas(),
+				tx.GasLimit(),
 				tx.ShardID(),
 				tx.ToShardID(),
 				tx.To(),
@@ -83,7 +84,7 @@ func SignTx(tx *types.Transaction, chainID *big.Int) ([]byte, string, error) {
 			[]interface{}{
 				tx.Nonce(),
 				tx.GasPrice(),
-				tx.Gas(),
+				tx.GasLimit(),
 				tx.ShardID(),
 				tx.ToShardID(),
 				tx.To(),
@@ -135,7 +136,7 @@ func SignTx(tx *types.Transaction, chainID *big.Int) ([]byte, string, error) {
 		[]interface{}{
 			tx.Nonce(),
 			tx.GasPrice(),
-			tx.Gas(),
+			tx.GasLimit(),
 			tx.ShardID(),
 			tx.ToShardID(),
 			tx.To(),


### PR DESCRIPTION
This PR uses the latest `harmony-one/harmony` version which introduces a change to the `types.Transaction` API where `tx.Gas()` is changed to `tx.GasLimit()`.