### PR TITLE
[console/cmd] add support for `data` signing

### DIFF
--- a/cmd/subcommands/transfer.go
+++ b/cmd/subcommands/transfer.go
@@ -42,6 +42,7 @@ var (
 	transferFileFlags []transferFlags
 	timeout           uint32
 	timeFormat        = "2006-01-02 15:04:05.000000"
+	data              string
 )
 
 type transactionLog struct {
@@ -169,6 +170,11 @@ func handlerForTransaction(txLog *transactionLog) error {
 		gLimit = uint64(tempLimit)
 	}
 
+	dataByte, err := transaction.StringToByte(data)
+	if err != nil {
+		return handlerForError(txLog, err)
+	}
+
 	addr := toAddress.String()
 
 	txLog.TimeSigned = time.Now().UTC().Format(timeFormat) // Approximate time of signature
@@ -177,7 +183,7 @@ func handlerForTransaction(txLog *transactionLog) error {
 		&addr,
 		fromShardID, toShardID,
 		amt, gPrice,
-		[]byte{},
+		dataByte,
 	)
 
 	if dryRun {
@@ -414,6 +420,7 @@ Create a transaction, sign it, and send off to the Harmony blockchain
 	cmdTransfer.Flags().StringVar(&inputNonce, "nonce", "", "set nonce for tx")
 	cmdTransfer.Flags().Uint32Var(&fromShardID, "from-shard", 0, "source shard id")
 	cmdTransfer.Flags().Uint32Var(&toShardID, "to-shard", 0, "target shard id")
+	cmdTransfer.Flags().StringVar(&data, "data", "", "transaction data")
 	cmdTransfer.Flags().StringVar(&targetChain, "chain-id", "", "what chain ID to target")
 	cmdTransfer.Flags().Uint32Var(&timeout, "timeout", defaultTimeout, "set timeout in seconds. Set to 0 to not wait for confirm")
 	cmdTransfer.Flags().BoolVar(&userProvidesPassphrase, "passphrase", false, ppPrompt)
@@ -449,7 +456,7 @@ Get Nonce From a Account
 		Short: "Send a Offline Signed transaction",
 		Args:  cobra.ExactArgs(0),
 		Long: `
-Send a offline signed to the Harmony blockchain
+Send a offline signed transaction to the Harmony blockchain
 `,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if givenFilePath == "" {

--- a/pkg/transaction/controller.go
+++ b/pkg/transaction/controller.go
@@ -205,7 +205,6 @@ func (C *Controller) setAmount(amount numeric.Dec) {
 			return
 		}
 	}
-
 	C.transactionForRPC.params["transfer-amount"] = amountInAtto
 }
 

--- a/pkg/transaction/ethcontroller.go
+++ b/pkg/transaction/ethcontroller.go
@@ -134,34 +134,37 @@ func (C *EthController) setAmount(amount numeric.Dec) {
 		})
 		return
 	}
-	balanceRPCReply, err := C.messenger.SendRPC(
-		rpc.Method.GetBalance,
-		p{address.ToBech32(C.sender.account.Address), "latest"},
-	)
-	if err != nil {
-		C.executionError = err
-		return
-	}
-	currentBalance, _ := balanceRPCReply["result"].(string)
-	bal, _ := new(big.Int).SetString(currentBalance[2:], 16)
-	balance := numeric.NewDecFromBigInt(bal)
+
 	gasAsDec := C.transactionForRPC.params["gas-price"].(numeric.Dec)
 	gasAsDec = gasAsDec.Mul(numeric.NewDec(int64(C.transactionForRPC.params["gas-limit"].(uint64))))
 	amountInAtto := amount.Mul(oneAsDec)
 	total := amountInAtto.Add(gasAsDec)
 
-	if total.GT(balance) {
-		balanceInOne := balance.Quo(oneAsDec)
-		C.executionError = ErrBadTransactionParam
-		errorMsg := fmt.Sprintf(
-			"insufficient balance of %s in shard %d for the requested transfer of %s",
-			balanceInOne.String(), C.transactionForRPC.params["from-shard"].(uint32), amount.String(),
+	if !C.Behavior.OfflineSign {
+		balanceRPCReply, err := C.messenger.SendRPC(
+			rpc.Method.GetBalance,
+			p{address.ToBech32(C.sender.account.Address), "latest"},
 		)
-		C.transactionErrors = append(C.transactionErrors, &Error{
-			ErrMessage:           &errorMsg,
-			TimestampOfRejection: time.Now().Unix(),
-		})
-		return
+		if err != nil {
+			C.executionError = err
+			return
+		}
+		currentBalance, _ := balanceRPCReply["result"].(string)
+		bal, _ := new(big.Int).SetString(currentBalance[2:], 16)
+		balance := numeric.NewDecFromBigInt(bal)
+		if total.GT(balance) {
+			balanceInOne := balance.Quo(oneAsDec)
+			C.executionError = ErrBadTransactionParam
+			errorMsg := fmt.Sprintf(
+				"insufficient balance of %s in shard %d for the requested transfer of %s",
+				balanceInOne.String(), C.transactionForRPC.params["from-shard"].(uint32), amount.String(),
+			)
+			C.transactionErrors = append(C.transactionErrors, &Error{
+				ErrMessage:           &errorMsg,
+				TimestampOfRejection: time.Now().Unix(),
+			})
+			return
+		}
 	}
 	C.transactionForRPC.params["transfer-amount"] = amountInAtto
 }
@@ -304,4 +307,10 @@ func (C *EthController) ExecuteEthTransaction(
 	return C.executionError
 }
 
-// TODO: add logic to create staking transactions in the SDK.
+func (C *EthController) ExecuteRawTransaction(txn string) error {
+	C.transactionForRPC.signature = &txn
+
+	C.sendSignedTx()
+	C.txConfirmation()
+	return C.executionError
+}

--- a/pkg/transaction/util.go
+++ b/pkg/transaction/util.go
@@ -1,0 +1,17 @@
+package transaction
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+func StringToByte(dataStr string) ([]byte, error) {
+	if len(dataStr) == 0 {
+		return []byte{}, nil
+	}
+	if !strings.HasPrefix(dataStr, "0x") {
+		return nil, fmt.Errorf("invalid data literal: %q", dataStr)
+	}
+	return hex.DecodeString(dataStr[2:])
+}


### PR DESCRIPTION
Supersedes #287 

Example:
#### Ethereum transaction
```py
#!/usr/bin/python3
from pyhmy import signing

tx = {
    'chainId': 1666700000,
    'data': "0xabcd",
    'gas': 21000,
    'gasPrice': 100000000000,
    'nonce': 0,
    'to': "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
    'value': 1000000000000000000
}
print(
    signing.sign_transaction(
        tx,
        "0x1111111111111111111111111111111111111111111111111111111111111111"
    ).rawTransaction.hex()
)
```
Produces output
`0xf8728085174876e8008252089419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a764000082abcd84c6afa5e4a0e85acf7a47cbd55a47bd778f3dc0446db45343fc3ef3a998f4449b2b58fcf1baa07af989a4543bfcae3746b6d59df4704e279721017946c8f9d46b150bc5787786`

The same transaction signed using `hmy`
```bash
$ hmy eth-transfer --offline-sign --nonce=0 --from=one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 --to=one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 --amount=1 --data=0xabcd --chain-id=1666700000 --gas-limit=21000 --gas-price=100      
```
produces output
```json
{
  "transaction": {
    "gas": "0x5208",
    "gasPrice": "0x174876e800",
    "hash": "0x56ff3ed959674fed39ff34abffbf3add4765eacfae6d14cfa3854f1d0b34e54d",
    "input": "0xabcd",
    "nonce": "0x0",
    "r": "0xe85acf7a47cbd55a47bd778f3dc0446db45343fc3ef3a998f4449b2b58fcf1ba",
    "s": "0x7af989a4543bfcae3746b6d59df4704e279721017946c8f9d46b150bc5787786",
    "to": "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
    "v": "0xc6afa5e4",
    "value": "0xde0b6b3a7640000"
  },
  "raw-transaction": "0xf8728085174876e8008252089419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a764000082abcd84c6afa5e4a0e85acf7a47cbd55a47bd778f3dc0446db45343fc3ef3a998f4449b2b58fcf1baa07af989a4543bfcae3746b6d59df4704e279721017946c8f9d46b150bc5787786",
  "time-signed-utc": "2022-10-19 14:15:47.706607"
}
```

#### Harmony transaction
Tested with `pyhmy>=0.1.2` - see harmony-one/pyhmy#38 and harmony-one/pyhmy#39 for more information. This will _not_ work with `pyhmy<0.1.2` because the our nodes are built with Ethereum compatibility in mind. Thus, when an Ethereum compatible chain id (or larger) is supplied, the [hash of the transaction disregards the `ShardID` and `ToShardID` but keeps those fields for `rlp` encoding the signed transaction object](https://github.com/harmony-one/harmony/blob/f8879f5e0288157bf95ae2898a9a27f0c85ff9ad/core/types/transaction_signing.go#L173).
```py
#!/usr/bin/python3

from pyhmy import signing

transaction_dict = {
    "chainId": 1666600000,
    "gas": 21000,
    "gasPrice": 100000000000,
    "nonce": 0,
    "shardID": 0,
    "to": "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
    "toShardID": 1,
    "value": 1000000000000000000,
    "data": "0xabcd",
}
signed_tx = signing.sign_transaction(
    transaction_dict,
    "0x1111111111111111111111111111111111111111111111111111111111111111",
)
print( signed_tx.rawTransaction.hex() )
```
produces an output
`0xf8748085174876e80082520880019419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a764000082abcd84c6ac98a4a0ef05b0bc0827ddd046ee8196253c6609484e28b8f250d860736ce8e053469f04a07229a88ce68241a9e77dcb1592a67a9a6a215d855a784467c9f550f8c4cb9b76`

The same transaction created using `hmy` is 
```bash
$ hmy transfer --offline-sign --nonce=0 --from=one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 --to=one1r8n7xah8cgfm0el8u3kvwzja6zrd4le2ntjy82 --amount=1 --gas-limit=21000 --gas-price=100 --from-shard 0 --to-shard 1 --chain-id=1666600000 --data 0xabcd
```
produces an output
```json
[
  {
    "transaction": {
      "gas": "0x5208",
      "gasPrice": "0x174876e800",
      "hash": "0x830ecc74ab7c6b9c29db24e55ca87358ed5777f16f554783e7e3548701e8055f",
      "input": "0xabcd",
      "nonce": "0x0",
      "r": "0xef05b0bc0827ddd046ee8196253c6609484e28b8f250d860736ce8e053469f04",
      "s": "0x7229a88ce68241a9e77dcb1592a67a9a6a215d855a784467c9f550f8c4cb9b76",
      "shardID": 0,
      "to": "0x19e7e376e7c213b7e7e7e46cc70a5dd086daff2a",
      "toShardID": 1,
      "v": "0xc6ac98a4",
      "value": "0xde0b6b3a7640000"
    },
    "raw-transaction": "0xf8748085174876e80082520880019419e7e376e7c213b7e7e7e46cc70a5dd086daff2a880de0b6b3a764000082abcd84c6ac98a4a0ef05b0bc0827ddd046ee8196253c6609484e28b8f250d860736ce8e053469f04a07229a88ce68241a9e77dcb1592a67a9a6a215d855a784467c9f550f8c4cb9b76",
    "time-signed-utc": "2022-10-19 20:23:51.799451"
  }
]
```