### PR TITLE
pkg/ledger: fix transaction signing

### DIFF
--- a/pkg/ledger/nano_S_driver.go
+++ b/pkg/ledger/nano_S_driver.go
@@ -210,7 +210,7 @@ func (n *NanoS) GetAddress() (oneAddr string, err error) {
 func (n *NanoS) SignTxn(txn []byte) (sig [signatureSize]byte, err error) {
 	buf := bytes.NewBuffer(txn)
 	var resp []byte
-	
+
 	for buf.Len() > 0 {
 		var p1 byte = p1More
 		var p2 byte = p2SignHash
@@ -273,14 +273,14 @@ func OpenNanoS() (*NanoS, error) {
 	)
 
 	// search for Nano S
-	devices, err := hid.Enumerate(ledgerVendorID, ledgerNanoSProductID)
+	devices, err := hid.EnumerateHid(ledgerVendorID, ledgerNanoSProductID)
 	if err != nil {
 		return nil, err
 	}
 	if len(devices) == 0 {
-		return nil, errors.New("Nano S not detected")
+		return nil, errors.New("nano S not detected")
 	} else if len(devices) > 1 {
-		return nil, errors.New("Unexpected error -- Is the one wallet app running?")
+		return nil, errors.New("detected multiple Nano S devices")
 	}
 
 	// open the device

--- a/pkg/ledger/nano_S_driver.go
+++ b/pkg/ledger/nano_S_driver.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 
-	hid "github.com/karalabe/usb"
+	"github.com/karalabe/usb"
 )
 
 const (
@@ -273,7 +273,7 @@ func OpenNanoS() (*NanoS, error) {
 	)
 
 	// search for Nano S
-	devices, err := hid.EnumerateHid(ledgerVendorID, ledgerNanoSProductID)
+	devices, err := usb.EnumerateHid(ledgerVendorID, ledgerNanoSProductID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Split the message to be signed into packets of size 255. The implementation is simply copied over from staking transaction signing.

Closes #297

See also harmony-one/staking-dashboard#637