### PR TITLE
[github action] ubuntu22 and fix macos build

### DIFF
--- a/.github/workflows/hmybuild.yml
+++ b/.github/workflows/hmybuild.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-latest ]
+        os: [ ubuntu-22.04, macos-latest ]
 
     steps:
       - name: Checkout hmy code
@@ -65,7 +65,7 @@ jobs:
           echo ${GOROOT}
 
       - name: Build hmy binary for Linux
-        if: matrix.os == 'ubuntu-18.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           make static
         working-directory: go-sdk
@@ -75,8 +75,9 @@ jobs:
         run: |
           brew install gmp
           brew install openssl
-          sudo ln -sf /opt/homebrew/opt/openssl@3 /usr/local/opt/openssl
-          echo "ls -l /usr/local/opt/"; ls -l /usr/local/opt/
+          sudo mkdir -p /opt/homebrew/opt/  
+          sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
+          echo "ls -l /opt/homebrew/opt/openssl@1.1"; ls -l /opt/homebrew/opt/openssl@1.1
           make libs
         working-directory: ${{ github.workspace }}/src/github.com/harmony-one/harmony
 
@@ -171,7 +172,7 @@ jobs:
   release-page:
     name: Sign binary and create and publish release page
     needs: [ build-x86_64 ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v3

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-latest ]
+        os: [ ubuntu-22.04, macos-latest ]
 
     steps:
       - name: Checkout hmy code
@@ -64,7 +64,7 @@ jobs:
           ls ${{ github.workspace }}/src/github.com/harmony-one/
 
       - name: Build hmy binary for linux ubuntu
-        if: matrix.os == 'ubuntu-18.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           make static
         working-directory: go-sdk
@@ -74,8 +74,9 @@ jobs:
         run: |
           brew install gmp
           brew install openssl
-          sudo ln -sf /opt/homebrew/opt/openssl@3 /usr/local/opt/openssl
-          echo "ls -l /usr/local/opt/"; ls -l /usr/local/opt/
+          sudo mkdir -p /opt/homebrew/opt/  
+          sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
+          echo "ls -l /opt/homebrew/opt/openssl@1.1"; ls -l /opt/homebrew/opt/openssl@1.1
           make libs
         working-directory: ${{ github.workspace }}/src/github.com/harmony-one/harmony
 


### PR DESCRIPTION
this PR updates the github actions script :
- use ubuntu 22 as deprecation has been announced
- fix the macos build