### PR TITLE
governance: fix voting support for `approval` etc

### DIFF
--- a/.github/workflows/hmybuild.yml
+++ b/.github/workflows/hmybuild.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: hmy
-          path: ${{ github.workspace }}/go-sdk/dist/*
+          path: ${{ github.workspace }}/src/github.com/harmony-one/go-sdk/dist/hmy
           retention-days: 1
 
   # build-arm64:

--- a/.github/workflows/hmybuild.yml
+++ b/.github/workflows/hmybuild.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           brew install gmp
           brew install openssl
-          sudo mkdir -p /opt/homebrew/opt/  
+          sudo mkdir -p /opt/homebrew/opt/
           sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
           echo "ls -l /opt/homebrew/opt/openssl@1.1"; ls -l /opt/homebrew/opt/openssl@1.1
           make libs

--- a/.github/workflows/hmybuild.yml
+++ b/.github/workflows/hmybuild.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: hmy
-          path: ${{ github.workspace }}/src/github.com/harmony-one/go-sdk/dist/hmy
+          path: ${{ github.workspace }}/go-sdk/dist/*
           retention-days: 1
 
   # build-arm64:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,6 +84,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make all
+          mv dist/hmy dist/hmy-darwin-x86_64
         working-directory: go-sdk
 
       - name: Upload artifact

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -84,12 +84,20 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           make all
-          mv dist/hmy dist/hmy-darwin-x86_64
         working-directory: go-sdk
 
-      - name: Upload artifact
+      - name: Upload artifact for linux
         uses: actions/upload-artifact@v3
+        if: matrix.os == 'ubuntu-22.04'
         with:
-          name: hmy
+          name: hmy-linux
+          path: ${{ github.workspace }}/go-sdk/dist/*
+          retention-days: 1
+
+      - name: Upload artifact for darwin
+        uses: actions/upload-artifact@v3
+        if: matrix.os == 'macos-latest'
+        with:
+          name: hmy-darwin
           path: ${{ github.workspace }}/go-sdk/dist/*
           retention-days: 1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,6 +69,13 @@ jobs:
           make static
         working-directory: go-sdk
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hmy
+          path: ${{ github.workspace }}/go-sdk/dist/*
+          retention-days: 1
+
       - name: Build libs for macos-latest
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,19 +69,12 @@ jobs:
           make static
         working-directory: go-sdk
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: hmy
-          path: ${{ github.workspace }}/go-sdk/dist/*
-          retention-days: 1
-
       - name: Build libs for macos-latest
         if: matrix.os == 'macos-latest'
         run: |
           brew install gmp
           brew install openssl
-          sudo mkdir -p /opt/homebrew/opt/  
+          sudo mkdir -p /opt/homebrew/opt/
           sudo ln -sf /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1
           echo "ls -l /opt/homebrew/opt/openssl@1.1"; ls -l /opt/homebrew/opt/openssl@1.1
           make libs
@@ -92,3 +85,10 @@ jobs:
         run: |
           make all
         working-directory: go-sdk
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hmy
+          path: ${{ github.workspace }}/go-sdk/dist/*
+          retention-days: 1


### PR DESCRIPTION
- approval and ranked-choice (uint32[]) => []interface{}
- quadratic / weighted / shutter => unchanged
- single-choice => unchanged
- return error if unknown type
- remove panic when converting to uint64
- add examples as comments for each of the proposal types. these have been verified by comparing with snapshot.js output

```js
// "@snapshot-labs/snapshot.js": "0.4.16",
import snapshot from '@snapshot-labs/snapshot.js';
// "ethers": "5.7",
import { Wallet } from "ethers";

  const hub = 'https://hub.snapshot.org';
  const client = new snapshot.Client712(hub);
  const signer = new Wallet("5a59d518386f3d11eaf978d1874bf7e3ba400f4c0b4ebd750250e6f4e26b15d5");
  const receipt = client.vote(signer, "0x0F22ec8F25fA6EaBc8f8F6B3Eb0645f0e4ea43Bd", {
    space: 'harmony-mainnet.eth',
    proposal: '0x80b87627254aa71870407a3c95742aa30c0e5ccdc81da23a1a54dcf0108778ae',
    type: 'single-choice',
    choice: "1",
    app: 'my-app',
  });
```