### PR TITLE
fix(staking): bind BLS proof to validator address after BloomEpoch

### DIFF
--- a/cmd/subcommands/staking.go
+++ b/cmd/subcommands/staking.go
@@ -85,6 +85,92 @@ var (
 	errNegativeAmount                  = errors.New("amount can not be negative")
 )
 
+func bloomEpochForChainID(chainID int64) (int64, bool) {
+	switch chainID {
+	case 0:
+		return 5, true // localnet
+	case 1:
+		return 2964, true // mainnet
+	case 2:
+		return 7414, true // testnet
+	case 4:
+		return 53508, true // partner/devnet
+	default:
+		return 0, false
+	}
+}
+
+func parseRPCEpoch(raw interface{}) (int64, error) {
+	switch v := raw.(type) {
+	case float64:
+		return int64(v), nil
+
+	case string:
+		s := strings.TrimSpace(v)
+
+		if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+			u, err := strconv.ParseUint(s[2:], 16, 64)
+			if err != nil {
+				return 0, err
+			}
+
+			return int64(u), nil
+		}
+
+		return strconv.ParseInt(s, 10, 64)
+
+	case int:
+		return int64(v), nil
+
+	case int64:
+		return v, nil
+
+	case uint64:
+		return int64(v), nil
+
+	default:
+		return 0, errors.Errorf("unsupported hmy_getEpoch result type %T", raw)
+	}
+}
+
+func getCurrentEpoch(networkHandler *rpc.HTTPMessenger) (int64, error) {
+	reply, err := networkHandler.SendRPC("hmy_getEpoch", []interface{}{})
+	if err != nil {
+		return 0, err
+	}
+
+	raw, ok := reply["result"]
+	if !ok || raw == nil {
+		return 0, errors.New("hmy_getEpoch returned empty result")
+	}
+
+	return parseRPCEpoch(raw)
+}
+
+func currentBLSProofConfig(networkHandler *rpc.HTTPMessenger) (keys.BLSProofConfig, error) {
+	cfg := keys.BLSProofConfig{
+		ValidatorAddress: address.Parse(validatorAddress.String()),
+	}
+
+	if chainName.chainID == nil || chainName.chainID.Value == nil {
+		return cfg, errors.New("chain ID is not initialized")
+	}
+
+	bloomEpoch, ok := bloomEpochForChainID(chainName.chainID.Value.Int64())
+	if !ok {
+		return cfg, nil
+	}
+
+	currentEpoch, err := getCurrentEpoch(networkHandler)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.BindToAddress = currentEpoch >= bloomEpoch
+
+	return cfg, nil
+}
+
 func createStakingTransaction(nonce uint64, f staking.StakeMsgFulfiller) (*staking.StakingTransaction, error) {
 	gPrice, err := common.NewDecFromString(gasPrice)
 	if err != nil {
@@ -351,7 +437,12 @@ Create a new validator"
 				blsPubKeys[i].FromLibBLSPublicKey(blsPubKey)
 			}
 
-			blsSigs, err := keys.VerifyBLSKeys(stakingBlsPubKeys, blsPubKeyDir)
+			blsProofCfg, err := currentBLSProofConfig(networkHandler)
+			if err != nil {
+				return err
+			}
+
+			blsSigs, err := keys.VerifyBLSKeysWithConfig(stakingBlsPubKeys, blsPubKeyDir, blsProofCfg)
 			if err != nil {
 				return err
 			}
@@ -522,10 +613,16 @@ Create a new validator"
 				shardKey.FromLibBLSPublicKey(blsKey)
 				shardPubKeyAdd = &shardKey
 
-				sig, err := keys.VerifyBLS(strings.TrimPrefix(slotKeyToAdd, "0x"), blsPubKeyDir)
+				blsProofCfg, err := currentBLSProofConfig(networkHandler)
 				if err != nil {
 					return err
 				}
+
+				sig, err := keys.VerifyBLSWithConfig(
+					strings.TrimPrefix(slotKeyToAdd, "0x"),
+					blsPubKeyDir,
+					blsProofCfg,
+				)
 				sigBls = &sig
 			}
 

--- a/pkg/keys/bls.go
+++ b/pkg/keys/bls.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"strings"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	bls_core "github.com/harmony-one/bls/ffi/go/bls"
 	"github.com/harmony-one/go-sdk/pkg/common"
 	"github.com/harmony-one/go-sdk/pkg/sharding"
@@ -26,7 +27,12 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-//BlsKey - struct to represent bls key data
+type BLSProofConfig struct {
+	ValidatorAddress ethcommon.Address
+	BindToAddress    bool
+}
+
+// BlsKey - struct to represent bls key data
 type BlsKey struct {
 	PrivateKey     *bls_core.SecretKey
 	PublicKey      *bls_core.PublicKey
@@ -37,7 +43,7 @@ type BlsKey struct {
 	ShardPublicKey *bls.SerializedPublicKey
 }
 
-//Initialize - initialize a bls key and assign a random private bls key if not already done
+// Initialize - initialize a bls key and assign a random private bls key if not already done
 func (blsKey *BlsKey) Initialize() {
 	if blsKey.PrivateKey == nil {
 		blsKey.PrivateKey = bls.RandPrivateKey()
@@ -47,7 +53,7 @@ func (blsKey *BlsKey) Initialize() {
 	}
 }
 
-//Reset - resets the currently assigned private and public key fields
+// Reset - resets the currently assigned private and public key fields
 func (blsKey *BlsKey) Reset() {
 	blsKey.PrivateKey = nil
 	blsKey.PrivateKeyHex = ""
@@ -153,30 +159,53 @@ func GetPublicBlsKey(privateKeyHex string) error {
 }
 
 func VerifyBLSKeys(blsPubKeys []string, blsPubKeyDir string) ([]bls.SerializedSignature, error) {
+	return VerifyBLSKeysWithConfig(blsPubKeys, blsPubKeyDir, BLSProofConfig{})
+}
+
+func VerifyBLSKeysWithConfig(
+	blsPubKeys []string,
+	blsPubKeyDir string,
+	cfg BLSProofConfig,
+) ([]bls.SerializedSignature, error) {
 	blsSigs := make([]bls.SerializedSignature, len(blsPubKeys))
+
 	for i := 0; i < len(blsPubKeys); i++ {
-		sig, err := VerifyBLS(strings.TrimPrefix(blsPubKeys[i], "0x"), blsPubKeyDir)
+		sig, err := VerifyBLSWithConfig(strings.TrimPrefix(blsPubKeys[i], "0x"), blsPubKeyDir, cfg)
 		if err != nil {
 			return nil, err
 		}
+
 		blsSigs[i] = sig
 	}
+
 	return blsSigs, nil
 }
 
 func VerifyBLS(blsPubKey string, blsPubKeyDir string) (bls.SerializedSignature, error) {
+	return VerifyBLSWithConfig(blsPubKey, blsPubKeyDir, BLSProofConfig{})
+}
+
+func VerifyBLSWithConfig(
+	blsPubKey string,
+	blsPubKeyDir string,
+	cfg BLSProofConfig,
+) (bls.SerializedSignature, error) {
 	var sig bls.SerializedSignature
 	var encryptedPrivateKeyBytes []byte
 	var pass []byte
 	var err error
+
 	// specified blsPubKeyDir
 	if len(blsPubKeyDir) != 0 {
 		filePath := fmt.Sprintf("%s/%s.key", blsPubKeyDir, blsPubKey)
+
 		encryptedPrivateKeyBytes, err = ioutil.ReadFile(filePath)
 		if err != nil {
 			return sig, common.ErrFoundNoKey
 		}
+
 		passFile := fmt.Sprintf("%s/%s.pass", blsPubKeyDir, blsPubKey)
+
 		pass, err = ioutil.ReadFile(passFile)
 		if err != nil {
 			return sig, common.ErrFoundNoPass
@@ -186,36 +215,44 @@ func VerifyBLS(blsPubKey string, blsPubKeyDir string) (bls.SerializedSignature, 
 		// if not ask for the absolute path
 		cwd, _ := os.Getwd()
 		filePath := fmt.Sprintf("%s/%s.key", cwd, blsPubKey)
+
 		encryptedPrivateKeyBytes, err = ioutil.ReadFile(filePath)
 		if err != nil {
 			reader := bufio.NewReader(os.Stdin)
+
 			fmt.Printf("For bls public key: %s\n", blsPubKey)
 			fmt.Println("Enter the absolute path to the encrypted bls private key file:")
+
 			filePath, _ := reader.ReadString('\n')
+			filePath = strings.TrimSpace(filePath)
+
 			if !path.IsAbs(filePath) {
 				return sig, common.ErrNotAbsPath
 			}
-			filePath = strings.TrimSpace(filePath)
+
 			encryptedPrivateKeyBytes, err = ioutil.ReadFile(filePath)
 			if err != nil {
 				return sig, err
 			}
 		}
-		// ask passphrase for bls key twice
+
 		fmt.Println("Enter the bls passphrase:")
 		pass, _ = terminal.ReadPassword(int(os.Stdin.Fd()))
 	}
 
 	cleanPass := strings.TrimSpace(string(pass))
 	cleanPass = strings.ReplaceAll(cleanPass, "\t", "")
+
 	decryptedPrivateKeyBytes, err := decrypt(encryptedPrivateKeyBytes, cleanPass)
 	if err != nil {
 		return sig, err
 	}
+
 	privateKey, err := getBlsKey(string(decryptedPrivateKeyBytes))
 	if err != nil {
 		return sig, err
 	}
+
 	publicKey := privateKey.GetPublicKey()
 	publicKeyHex := publicKey.SerializeToHexStr()
 
@@ -224,14 +261,29 @@ func VerifyBLS(blsPubKey string, blsPubKeyDir string) (bls.SerializedSignature, 
 	}
 
 	messageBytes := []byte(types.BLSVerificationStr)
+
+	if cfg.BindToAddress {
+		if cfg.ValidatorAddress == (ethcommon.Address{}) {
+			return sig, errors.New("validator address is required for address-bound bls proof")
+		}
+
+		boundMessageBytes := make([]byte, 0, ethcommon.AddressLength+len(messageBytes))
+		boundMessageBytes = append(boundMessageBytes, cfg.ValidatorAddress.Bytes()...)
+		boundMessageBytes = append(boundMessageBytes, messageBytes...)
+		messageBytes = boundMessageBytes
+	}
+
 	msgHash := hash.Keccak256(messageBytes)
+
 	signature := privateKey.SignHash(msgHash[:])
 
 	bytes := signature.Serialize()
 	if len(bytes) != bls.BLSSignatureSizeInBytes {
 		return sig, errors.New("bls key length is not 96 bytes")
 	}
+
 	copy(sig[:], bytes)
+
 	return sig, nil
 }
 


### PR DESCRIPTION
Use legacy BLS proof signing before BloomEpoch and address-bound BLS proof signing after BloomEpoch. This matches staking verifier behavior on networks where BLS proof binding is active.


Test on the devnet node:
- The command under test is exactly `staking edit-validator --add-bls-key ... --bls-pubkeys-dir ... --passphrase --verbose`
- The CLI queried `hmy_getEpoch` and received `0xd1ab`
- The raw staking tx includes the target BLS key and the new proof signature prefix `235572fb...`, not the old failing `27cef726...` proof.
- RPC accepted the tx and returned hash `0x15142559c29b11e642f7c945836254f9c0db387545311f252d0462f9ac4f7962`. 
- The transaction error sink returned `[]`
- The successful receipt has `status: "0x1"`, the same tx hash, and sender `one1tedqsp6fm47cmp7xk5m44stvz8pxjmzursl2r5`.
- bls key is added:
```
$ ./hmy version
Harmony (C) 2020. hmy, version v485-v2026.0.0-0-g18f3451-dirty (uladzislau@harmony.one 2026-07-08T14:12:58+0300)
$ ./hmy --node="$NODE" blockchain validator information "$VAL" | grep -i "f6169575deda00e748c81c762fccfbd62a68ad907471ed16466fa2340cfe24293ee99ebbfd90c77a01b3d4c65a539008"
            "bls-public-key": "f6169575deda00e748c81c762fccfbd62a68ad907471ed16466fa2340cfe24293ee99ebbfd90c77a01b3d4c65a539008",
        "f6169575deda00e748c81c762fccfbd62a68ad907471ed16466fa2340cfe24293ee99ebbfd90c77a01b3d4c65a539008"
```
